### PR TITLE
[WHS-1] Implement GET /api/v1/employees/{id}

### DIFF
--- a/src/main/java/org/demo/whs/controller/EmployeeController.java
+++ b/src/main/java/org/demo/whs/controller/EmployeeController.java
@@ -1,6 +1,7 @@
 package org.demo.whs.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.dto.request.Employee.CreateEmployeeRequest;
@@ -34,5 +35,14 @@ public class EmployeeController {
         EmployeeResponse response = employeeService.create(createEmployeeRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(BaseResponse.success(response));
+    }
+
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<EmployeeResponse>> getEmployeeById(
+            @PathVariable @NotBlank(message = "Employee id is required") String id) {
+        log.info("Received request to get employee with id={}", id);
+        EmployeeResponse response = employeeService.getById(id);
+        return ResponseEntity.ok(BaseResponse.success(response));
     }
 }

--- a/src/main/java/org/demo/whs/service/EmployeeService.java
+++ b/src/main/java/org/demo/whs/service/EmployeeService.java
@@ -16,4 +16,12 @@ public interface EmployeeService {
      * @return created employee response
      */
     EmployeeResponse create(CreateEmployeeRequest request);
+
+    /**
+     * Get employee details by employee identifier.
+     *
+     * @param id employee identifier
+     * @return employee response
+     */
+    EmployeeResponse getById(String id);
 }

--- a/src/main/java/org/demo/whs/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/EmployeeServiceImpl.java
@@ -99,6 +99,20 @@ public class EmployeeServiceImpl implements EmployeeService {
         return employeeMapper.toResponse(employee, userProfile);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public EmployeeResponse getById(String id) {
+        log.info("Fetching employee with id={}", id);
+
+        Employee employee = employeeRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Employee not found", ErrorCode.EMP_001));
+
+        UserProfile userProfile = userProfileRepository.findByAccountId(employee.getAccountId())
+                .orElse(null);
+
+        return employeeMapper.toResponse(employee, userProfile);
+    }
+
     private void validateRequest(CreateEmployeeRequest request) {
         if (accountRepository.existsByUsername(request.getUsername())) {
             throw new BadRequestException(ErrorCode.COM_005);

--- a/src/test/java/org/demo/whs/controller/EmployeeControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/EmployeeControllerTest.java
@@ -1,0 +1,83 @@
+package org.demo.whs.controller;
+
+import org.demo.whs.entity.dto.response.Employee.EmployeeResponse;
+import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.exception.GlobalExceptionHandle;
+import org.demo.whs.exception.NotFoundException;
+import org.demo.whs.service.EmployeeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EmployeeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import({GlobalExceptionHandle.class})
+@ImportAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, FlywayAutoConfiguration.class})
+class EmployeeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EmployeeService employeeService;
+
+    @MockitoBean
+    private org.demo.whs.service.RateLimitService rateLimitService;
+
+    @Test
+    @DisplayName("should_Return200_When_GetEmployeeByIdSuccess")
+    void should_Return200_When_GetEmployeeByIdSuccess() throws Exception {
+        EmployeeResponse response = EmployeeResponse.builder()
+                .id("emp-1")
+                .employeeCode("EMP-001")
+                .firstName("Dung")
+                .build();
+
+        when(employeeService.getById("emp-1")).thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/employees/{id}", "emp-1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value("emp-1"))
+                .andExpect(jsonPath("$.data.employee_code").value("EMP-001"));
+    }
+
+    @Test
+    @DisplayName("should_Return404_When_GetEmployeeByIdNotFound")
+    void should_Return404_When_GetEmployeeByIdNotFound() throws Exception {
+        when(employeeService.getById("missing-id"))
+                .thenThrow(new NotFoundException("Employee not found", ErrorCode.EMP_001));
+
+        mockMvc.perform(get("/api/v1/employees/{id}", "missing-id")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Employee not found"));
+    }
+
+    @Test
+    @DisplayName("should_Return400_When_IdIsBlank")
+    void should_Return400_When_IdIsBlank() throws Exception {
+        mockMvc.perform(get("/api/v1/employees/{id}", " ")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+}

--- a/src/test/java/org/demo/whs/service/impl/EmployeeServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/EmployeeServiceImplTest.java
@@ -106,7 +106,8 @@ class EmployeeServiceImplTest {
         assertThatThrownBy(() -> employeeService.getById(employeeId))
                 .isInstanceOf(NotFoundException.class)
                 .hasFieldOrPropertyWithValue("status", HttpStatus.NOT_FOUND)
-                .hasMessage("Employee not found");
+                .hasMessage("Employee not found")
+                .satisfies(ex -> assertThat(((NotFoundException) ex).getErrorCode()).isEqualTo("EMP_001"));
 
         verify(employeeRepository).findById(employeeId);
     }

--- a/src/test/java/org/demo/whs/service/impl/EmployeeServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/EmployeeServiceImplTest.java
@@ -1,0 +1,145 @@
+package org.demo.whs.service.impl;
+
+import org.demo.whs.entity.Employee;
+import org.demo.whs.entity.UserProfile;
+import org.demo.whs.entity.dto.response.Employee.EmployeeResponse;
+import org.demo.whs.entity.enums.EmployeeStatus;
+import org.demo.whs.exception.NotFoundException;
+import org.demo.whs.mapper.EmployeeMapper;
+import org.demo.whs.repository.AccountHasRoleRepository;
+import org.demo.whs.repository.AccountRepository;
+import org.demo.whs.repository.EmployeeRepository;
+import org.demo.whs.repository.RoleRepository;
+import org.demo.whs.repository.UserProfileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EmployeeServiceImpl Unit Tests")
+class EmployeeServiceImplTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private AccountHasRoleRepository accountHasRoleRepository;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Mock
+    private EmployeeMapper employeeMapper;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private EmployeeServiceImpl employeeService;
+
+    @Test
+    @DisplayName("should_ReturnEmployeeResponse_When_EmployeeExists")
+    void should_ReturnEmployeeResponse_When_EmployeeExists() {
+        String employeeId = "emp-1";
+        String accountId = "acc-1";
+
+        Employee employee = Employee.builder()
+                .accountId(accountId)
+                .employeeCode("EMP-001")
+                .status(EmployeeStatus.ACTIVE)
+                .build();
+        employee.setId(employeeId);
+
+        UserProfile profile = UserProfile.builder()
+                .accountId(accountId)
+                .firstName("Dung")
+                .lastName("Hoang")
+                .email("dung@example.com")
+                .build();
+
+        EmployeeResponse expected = EmployeeResponse.builder()
+                .id(employeeId)
+                .accountId(accountId)
+                .employeeCode("EMP-001")
+                .firstName("Dung")
+                .lastName("Hoang")
+                .build();
+
+        when(employeeRepository.findById(employeeId)).thenReturn(Optional.of(employee));
+        when(userProfileRepository.findByAccountId(accountId)).thenReturn(Optional.of(profile));
+        when(employeeMapper.toResponse(employee, profile)).thenReturn(expected);
+
+        EmployeeResponse result = employeeService.getById(employeeId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(employeeId);
+        assertThat(result.getEmployeeCode()).isEqualTo("EMP-001");
+        verify(employeeRepository).findById(employeeId);
+        verify(userProfileRepository).findByAccountId(accountId);
+        verify(employeeMapper).toResponse(employee, profile);
+    }
+
+    @Test
+    @DisplayName("should_ThrowNotFoundException_When_EmployeeNotFound")
+    void should_ThrowNotFoundException_When_EmployeeNotFound() {
+        String employeeId = "emp-missing";
+        when(employeeRepository.findById(employeeId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> employeeService.getById(employeeId))
+                .isInstanceOf(NotFoundException.class)
+                .hasFieldOrPropertyWithValue("status", HttpStatus.NOT_FOUND)
+                .hasMessage("Employee not found");
+
+        verify(employeeRepository).findById(employeeId);
+    }
+
+    @Test
+    @DisplayName("should_ReturnEmployeeResponseWithoutProfile_When_UserProfileMissing")
+    void should_ReturnEmployeeResponseWithoutProfile_When_UserProfileMissing() {
+        String employeeId = "emp-2";
+        String accountId = "acc-2";
+
+        Employee employee = Employee.builder()
+                .accountId(accountId)
+                .employeeCode("EMP-002")
+                .status(EmployeeStatus.ACTIVE)
+                .build();
+        employee.setId(employeeId);
+
+        EmployeeResponse expected = EmployeeResponse.builder()
+                .id(employeeId)
+                .accountId(accountId)
+                .employeeCode("EMP-002")
+                .build();
+
+        when(employeeRepository.findById(employeeId)).thenReturn(Optional.of(employee));
+        when(userProfileRepository.findByAccountId(accountId)).thenReturn(Optional.empty());
+        when(employeeMapper.toResponse(employee, null)).thenReturn(expected);
+
+        EmployeeResponse result = employeeService.getById(employeeId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(employeeId);
+        verify(employeeRepository).findById(employeeId);
+        verify(userProfileRepository).findByAccountId(accountId);
+        verify(employeeMapper).toResponse(employee, null);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `GET /api/v1/employees/{id}` in `EmployeeController`
- add `getById(String id)` to `EmployeeService`
- implement read-only `getById` in `EmployeeServiceImpl`
- map employee + user profile to `EmployeeResponse`
- return `404` via existing `NotFoundException` when employee is not found

## Tests
- add `EmployeeControllerTest`
  - success: returns `200`
  - not found: returns `404`
  - blank id: returns `400`
- add `EmployeeServiceImplTest`
  - success with profile
  - not found
  - success when profile is missing

## Notes
- DB migration is not required for WHS-1 because `employees` schema/indexes already exist.
- Local Maven test execution could not be completed in this environment due restricted network access to Maven Central.