### PR TITLE
[WHS-70] Refactor inventory/adjustment/transfer/movement schema consistency

### DIFF
--- a/documents/Inventory/BA_DB_API_MODULE_04_INVENTORY_OPERATIONS_REDESIGN_V2.md
+++ b/documents/Inventory/BA_DB_API_MODULE_04_INVENTORY_OPERATIONS_REDESIGN_V2.md
@@ -509,4 +509,33 @@ Recommended additional task:
 
 ---
 
+## 17) WHS-70 Implementation Notes
+
+Implemented changes for `feature/WHS-70-inventory-schema-consistency`:
+
+1. New migration: `V20260404_01__Refactor_inventory_schema_consistency.sql`.
+2. `inventory` logical uniqueness now normalizes nullable dimensions (`location_id`, `batch_id`) before unique enforcement.
+3. `stock_adjustments` now enforces:
+   - non-negative quantities,
+   - arithmetic consistency (`adjustment_quantity = quantity_after - quantity_before`),
+   - non-zero delta,
+   - strict workflow metadata for pending/approved/rejected states.
+4. `stock_movements` and JPA entity mapping are aligned (including `warehouse_id`, nullable `location_id/reference` fields).
+5. `StockAdjustmentsServiceImpl` now fully implements:
+   - create (pending and auto-approved),
+   - approve/reject transition checks,
+   - atomic inventory + movement side effects.
+6. `StockTransfersServiceImpl` now fully implements:
+   - create/list/detail,
+   - complete/cancel transitions,
+   - atomic source/destination inventory updates with `TRANSFER_OUT` + `TRANSFER_IN` movements.
+7. Added integration tests for adjustment constraints and inventory optimistic lock behavior, plus unit tests for adjustment/transfer workflows.
+
+### Backward-Compatibility Notes
+
+1. `POST /api/v1/stock-adjustments` still accepts legacy fields (`product_id`, `warehouse_id`, `location_id`, `batch_id`, `quantity_before`) but now treats `inventory_id` as source-of-truth and derives snapshot values from inventory at runtime.
+2. `StockTransfersStatus` enum typo was fixed from `DAFT` to `DRAFT` to align with DB enum values. Any client-side use of `DAFT` must be updated.
+
+---
+
 **End of document**

--- a/src/main/java/org/demo/whs/controller/StockAdjustmentsController.java
+++ b/src/main/java/org/demo/whs/controller/StockAdjustmentsController.java
@@ -5,14 +5,20 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.dto.request.StockAdjustments.ApproveStockAdjustmentRequest;
 import org.demo.whs.entity.dto.request.StockAdjustments.RejectStockAdjustmentRequest;
+import org.demo.whs.entity.dto.request.StockAdjustments.SearchStockAdjustmentsRequest;
 import org.demo.whs.entity.dto.request.StockAdjustments.StockAdjustmentsRequest;
 import org.demo.whs.entity.dto.response.BaseResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.StockAdjustments.StockAdjustmentsResponse;
+import org.demo.whs.entity.enums.StockAdjustmentsStatus;
 import org.demo.whs.service.StockAdjustmentsService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 /**
  * Controller for managing stock adjustments.
@@ -33,6 +39,7 @@ public class StockAdjustmentsController {
      * @return a response entity containing the created stock adjustment response
      */
     @PostMapping
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<BaseResponse<StockAdjustmentsResponse>> createStockAdjustment(
             @RequestBody @Valid StockAdjustmentsRequest request) {
         log.info("Attempting to create stock adjustment with details: {}", request);
@@ -47,6 +54,7 @@ public class StockAdjustmentsController {
      * @return a response entity containing the retrieved stock adjustment response
      */
     @GetMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<BaseResponse<StockAdjustmentsResponse>> getStockAdjustment(
             @PathVariable String id) {
         log.info("Attempting to retrieve stock adjustment with ID: {}", id);
@@ -62,11 +70,39 @@ public class StockAdjustmentsController {
      * @return a response entity containing a paginated response of stock adjustments
      */
     @GetMapping
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<BaseResponse<PageResponse<StockAdjustmentsResponse>>> getStockAdjustments(
+            @RequestParam(required = false) StockAdjustmentsStatus status,
+            @RequestParam(required = false) String productId,
+            @RequestParam(required = false) String warehouseId,
+            @RequestParam(required = false) String inventoryId,
+            @RequestParam(required = false) String adjustmentNumber,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdTo,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         log.info("Attempting to retrieve stock adjustments with page: {} and size: {}", page, size);
-        PageResponse<StockAdjustmentsResponse> response = stockAdjustmentsService.getAll(page, size);
+
+        SearchStockAdjustmentsRequest searchRequest = new SearchStockAdjustmentsRequest();
+        searchRequest.setStatus(status);
+        searchRequest.setProductId(productId);
+        searchRequest.setWarehouseId(warehouseId);
+        searchRequest.setInventoryId(inventoryId);
+        searchRequest.setAdjustmentNumber(adjustmentNumber);
+        searchRequest.setCreatedFrom(createdFrom);
+        searchRequest.setCreatedTo(createdTo);
+
+        boolean hasFilters = status != null
+                || productId != null
+                || warehouseId != null
+                || inventoryId != null
+                || adjustmentNumber != null
+                || createdFrom != null
+                || createdTo != null;
+
+        PageResponse<StockAdjustmentsResponse> response = hasFilters
+                ? stockAdjustmentsService.search(searchRequest, page, size)
+                : stockAdjustmentsService.getAll(page, size);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 
@@ -78,6 +114,7 @@ public class StockAdjustmentsController {
      * @return a response entity containing the updated stock adjustment response after approval
      */
     @PutMapping("/{id}/approve")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<BaseResponse<StockAdjustmentsResponse>> approveStockAdjustment(
             @PathVariable String id,
             @RequestBody @Valid ApproveStockAdjustmentRequest request) {
@@ -94,6 +131,7 @@ public class StockAdjustmentsController {
      * @return a response entity containing the updated stock adjustment response after rejection
      */
     @PutMapping("/{id}/reject")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<BaseResponse<StockAdjustmentsResponse>> rejectStockAdjustment(
             @PathVariable String id,
             @RequestBody @Valid RejectStockAdjustmentRequest request) {

--- a/src/main/java/org/demo/whs/controller/StockMovementsController.java
+++ b/src/main/java/org/demo/whs/controller/StockMovementsController.java
@@ -2,6 +2,17 @@ package org.demo.whs.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.entity.dto.response.BaseResponse;
+import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.entity.dto.response.StockMovements.StockMovementsResponse;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.demo.whs.service.StockMovementsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,5 +23,35 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@Validated
 public class StockMovementsController {
+
+    private final StockMovementsService stockMovementsService;
+
+    @GetMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<StockMovementsResponse>> getMovement(@PathVariable String id) {
+        StockMovementsResponse response = stockMovementsService.getById(id);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<PageResponse<StockMovementsResponse>>> getMovements(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size) {
+        PageResponse<StockMovementsResponse> response = stockMovementsService.getAll(page, size);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @GetMapping("/reference/{referenceType}/{referenceId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<PageResponse<StockMovementsResponse>>> getMovementsByReference(
+            @PathVariable ReferenceType referenceType,
+            @PathVariable String referenceId,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size) {
+        PageResponse<StockMovementsResponse> response = stockMovementsService.getByReference(referenceType, referenceId, page, size);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
 }

--- a/src/main/java/org/demo/whs/controller/StockTransfersController.java
+++ b/src/main/java/org/demo/whs/controller/StockTransfersController.java
@@ -1,8 +1,22 @@
 package org.demo.whs.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.entity.dto.request.StockTransfers.StockTransfersRequest;
+import org.demo.whs.entity.dto.response.BaseResponse;
+import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.entity.dto.response.StockTransfers.StockTransfersResponse;
 import org.demo.whs.service.StockTransfersService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,6 +27,45 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@Validated
 public class StockTransfersController {
     private final StockTransfersService stockTransfersService;
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<StockTransfersResponse>> createTransfer(
+            @RequestBody @Valid StockTransfersRequest request) {
+        StockTransfersResponse response = stockTransfersService.createTransfer(request);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<StockTransfersResponse>> getTransfer(@PathVariable String id) {
+        StockTransfersResponse response = stockTransfersService.getById(id);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<PageResponse<StockTransfersResponse>>> getTransfers(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size) {
+        PageResponse<StockTransfersResponse> response = stockTransfersService.getAll(page, size);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @PutMapping("/{id}/complete")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<StockTransfersResponse>> completeTransfer(@PathVariable String id) {
+        StockTransfersResponse response = stockTransfersService.complete(id);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @PutMapping("/{id}/cancel")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<StockTransfersResponse>> cancelTransfer(@PathVariable String id) {
+        StockTransfersResponse response = stockTransfersService.cancel(id);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
 }

--- a/src/main/java/org/demo/whs/entity/Inventory.java
+++ b/src/main/java/org/demo/whs/entity/Inventory.java
@@ -3,6 +3,7 @@ package org.demo.whs.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -28,12 +29,13 @@ public class Inventory extends BaseEntity {
     @Column(name = "batch_id", length = 36, columnDefinition = "char(36)")
     private String batchId;
 
-    @Column(name = "on_hand_quantity", nullable = false, precision = 19, scale = 6)
+    @Column(name = "on_hand_quantity", nullable = false, precision = 15, scale = 2)
     private BigDecimal onHandQuantity;
 
-    @Column(name = "reserved_quantity", nullable = false, precision = 19, scale = 6)
+    @Column(name = "reserved_quantity", nullable = false, precision = 15, scale = 2)
     private BigDecimal reservedQuantity;
 
+    @Version
     @Column(name = "version", nullable = false)
     private Integer version;
 

--- a/src/main/java/org/demo/whs/entity/StockAdjustments.java
+++ b/src/main/java/org/demo/whs/entity/StockAdjustments.java
@@ -4,11 +4,17 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.demo.whs.entity.enums.ReasonType;
 import org.demo.whs.entity.enums.StockAdjustmentsStatus;
+import org.hibernate.annotations.Check;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "stock_adjustments")
+@Check(constraints = "quantity_before >= 0 AND quantity_after >= 0 " +
+        "AND adjustment_quantity = quantity_after - quantity_before " +
+        "AND adjustment_quantity <> 0 " +
+        "AND ((status <> 'APPROVED') OR (approved_by IS NOT NULL AND approved_at IS NOT NULL)) " +
+        "AND ((status <> 'REJECTED') OR (rejection_reason IS NOT NULL))")
 @Getter
 @Setter
 @Builder
@@ -34,13 +40,13 @@ public class StockAdjustments extends BaseEntity {
     @Column(name = "batch_id", length = 36, columnDefinition = "char(36)")
     private String batchId;
 
-    @Column(name = "quantity_before", nullable = false, precision = 15, scale = 5)
+    @Column(name = "quantity_before", nullable = false, precision = 15, scale = 2)
     private BigDecimal quantityBefore;
 
-    @Column(name = "quantity_after", nullable = false, precision = 15, scale = 5)
+    @Column(name = "quantity_after", nullable = false, precision = 15, scale = 2)
     private BigDecimal quantityAfter;
 
-    @Column(name = "adjustment_quantity", nullable = false, precision = 15, scale = 5)
+    @Column(name = "adjustment_quantity", nullable = false, precision = 15, scale = 2)
     private BigDecimal adjustmentQuantity;
 
     @Enumerated(EnumType.STRING)
@@ -63,6 +69,6 @@ public class StockAdjustments extends BaseEntity {
     @Column(name = "approved_at")
     private LocalDateTime approvedAt;
 
-    @Column(name = "rejection_reason", columnDefinition = "TEXT")
+    @Column(name = "rejection_reason", length = 500)
     private String rejectionReason;
 }

--- a/src/main/java/org/demo/whs/entity/StockAdjustments.java
+++ b/src/main/java/org/demo/whs/entity/StockAdjustments.java
@@ -13,8 +13,13 @@ import java.time.LocalDateTime;
 @Check(constraints = "quantity_before >= 0 AND quantity_after >= 0 " +
         "AND adjustment_quantity = quantity_after - quantity_before " +
         "AND adjustment_quantity <> 0 " +
-        "AND ((status <> 'APPROVED') OR (approved_by IS NOT NULL AND approved_at IS NOT NULL)) " +
-        "AND ((status <> 'REJECTED') OR (rejection_reason IS NOT NULL))")
+        "AND ((" +
+        "status = 'PENDING' AND approved_by IS NULL AND approved_at IS NULL AND rejection_reason IS NULL" +
+        ") OR (" +
+        "status = 'APPROVED' AND approved_by IS NOT NULL AND approved_at IS NOT NULL AND rejection_reason IS NULL" +
+        ") OR (" +
+        "status = 'REJECTED' AND approved_by IS NOT NULL AND approved_at IS NOT NULL AND rejection_reason IS NOT NULL" +
+        "))")
 @Getter
 @Setter
 @Builder

--- a/src/main/java/org/demo/whs/entity/StockMovements.java
+++ b/src/main/java/org/demo/whs/entity/StockMovements.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.demo.whs.entity.enums.ReferenceType;
 import org.demo.whs.entity.enums.StockMovementsType;
+import org.hibernate.annotations.Check;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Table(name = "stock_movements")
+@Check(constraints = "quantity_after = quantity_before + quantity_change AND quantity_before >= 0 AND quantity_after >= 0")
 @Getter
 @Setter
 @Builder
@@ -21,12 +23,15 @@ public class StockMovements extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "movement_type", nullable = false)
-    private StockMovementsType movementsType;
+    private StockMovementsType movementType;
 
     @Column(name = "product_id", nullable = false, columnDefinition = ("CHAR(36)"))
     private String productId;
 
-    @Column(name = "location_id", nullable = false, columnDefinition = ("CHAR(36)"))
+    @Column(name = "warehouse_id", nullable = false, columnDefinition = ("CHAR(36)"))
+    private String warehouseId;
+
+    @Column(name = "location_id", columnDefinition = ("CHAR(36)"))
     private String locationId;
 
     @Column(name = "batch_id", columnDefinition = ("CHAR(36)"))
@@ -48,10 +53,10 @@ public class StockMovements extends BaseEntity {
     @Column(name = "reference_type", nullable = false)
     private ReferenceType referenceType;
 
-    @Column(name = "reference_id", nullable = false, columnDefinition = ("CHAR(36)"))
+    @Column(name = "reference_id", columnDefinition = ("CHAR(36)"))
     private String referenceId;
 
-    @Column(name = "reference_number", nullable = false)
+    @Column(name = "reference_number")
     private String referenceNumber;
 
     @Column(name = "notes", columnDefinition = ("TEXT"))

--- a/src/main/java/org/demo/whs/entity/dto/request/StockAdjustments/StockAdjustmentsRequest.java
+++ b/src/main/java/org/demo/whs/entity/dto/request/StockAdjustments/StockAdjustmentsRequest.java
@@ -17,18 +17,29 @@ public class StockAdjustmentsRequest {
     @NotBlank(message = "Inventory ID is required")
     private String inventoryId;
 
-    @NotBlank(message = "Product ID is required")
+    /**
+     * Backward-compatibility field. The authoritative value is loaded from inventory_id.
+     */
     private String productId;
 
-    @NotBlank(message = "Warehouse ID is required")
+    /**
+     * Backward-compatibility field. The authoritative value is loaded from inventory_id.
+     */
     private String warehouseId;
 
+    /**
+     * Backward-compatibility field. The authoritative value is loaded from inventory_id.
+     */
     private String locationId;
 
+    /**
+     * Backward-compatibility field. The authoritative value is loaded from inventory_id.
+     */
     private String batchId;
 
-    @NotNull(message = "Quantity before is required")
-    @DecimalMin(value = "0.00", message = "Quantity before must be greater than or equal to 0")
+    /**
+     * Backward-compatibility field. The authoritative value is loaded from inventory_id.
+     */
     private BigDecimal quantityBefore;
 
     @NotNull(message = "Quantity after is required")

--- a/src/main/java/org/demo/whs/entity/dto/request/StockTransfers/StockTransfersRequest.java
+++ b/src/main/java/org/demo/whs/entity/dto/request/StockTransfers/StockTransfersRequest.java
@@ -2,9 +2,40 @@ package org.demo.whs.entity.dto.request.StockTransfers;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import org.demo.whs.entity.enums.StockTransfersReason;
+
+import java.math.BigDecimal;
 
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class StockTransfersRequest {
+
+    @NotBlank(message = "Product ID is required")
+    private String productId;
+
+    @NotBlank(message = "Warehouse ID is required")
+    private String warehouseId;
+
+    @NotBlank(message = "From location ID is required")
+    private String fromLocationId;
+
+    @NotBlank(message = "To location ID is required")
+    private String toLocationId;
+
+    private String batchId;
+
+    @NotNull(message = "Transfer quantity is required")
+    @DecimalMin(value = "0.01", message = "Transfer quantity must be greater than 0")
+    private BigDecimal quantity;
+
+    @NotNull(message = "Transfer reason is required")
+    private StockTransfersReason reason;
+
+    @Size(max = 2000, message = "Notes must not exceed 2000 characters")
+    private String notes;
 }

--- a/src/main/java/org/demo/whs/entity/dto/response/StockMovements/StockMovementsResponse.java
+++ b/src/main/java/org/demo/whs/entity/dto/response/StockMovements/StockMovementsResponse.java
@@ -1,9 +1,33 @@
 package org.demo.whs.entity.dto.response.StockMovements;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Getter;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.demo.whs.entity.enums.StockMovementsType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class StockMovementsResponse {
+    private String id;
+    private StockMovementsType movementType;
+    private String productId;
+    private String warehouseId;
+    private String locationId;
+    private String batchId;
+    private BigDecimal quantityChange;
+    private BigDecimal quantityBefore;
+    private BigDecimal quantityAfter;
+    private LocalDateTime movementDate;
+    private ReferenceType referenceType;
+    private String referenceId;
+    private String referenceNumber;
+    private String notes;
+    private String createdBy;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/org/demo/whs/entity/dto/response/StockTransfers/StockTransfersResponse.java
+++ b/src/main/java/org/demo/whs/entity/dto/response/StockTransfers/StockTransfersResponse.java
@@ -4,9 +4,30 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Getter;
+import org.demo.whs.entity.enums.StockTransfersReason;
+import org.demo.whs.entity.enums.StockTransfersStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class StockTransfersResponse {
+    private String id;
+    private String transferNumber;
+    private String productId;
+    private String warehouseId;
+    private String fromLocationId;
+    private String toLocationId;
+    private String batchId;
+    private BigDecimal quantity;
+    private StockTransfersReason reason;
+    private String notes;
+    private StockTransfersStatus status;
+    private LocalDateTime completedAt;
+    private String createdBy;
+    private LocalDateTime createdAt;
+    private String updatedBy;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/demo/whs/entity/enums/StockTransfersStatus.java
+++ b/src/main/java/org/demo/whs/entity/enums/StockTransfersStatus.java
@@ -1,7 +1,7 @@
 package org.demo.whs.entity.enums;
 
 public enum StockTransfersStatus {
-    DAFT,
+    DRAFT,
     COMPLETED,
     CANCELLED
 }

--- a/src/main/java/org/demo/whs/exception/BadRequestException.java
+++ b/src/main/java/org/demo/whs/exception/BadRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public class BadRequestException extends BaseException {
     public BadRequestException(String message, ErrorCode errorCode) {
-        super(message, errorCode.getMessage(), HttpStatus.BAD_REQUEST);
+        super(errorCode.getCode(), message, HttpStatus.BAD_REQUEST);
     }
 
     public BadRequestException(ErrorCode errorCode) {

--- a/src/main/java/org/demo/whs/exception/ErrorCode.java
+++ b/src/main/java/org/demo/whs/exception/ErrorCode.java
@@ -40,6 +40,13 @@ public enum ErrorCode {
     WH_002("WHS_002", "Insufficient stock in warehouse"),
     WH_003("WHS_003", "Invalid warehouse operation"),
     WH_004("WHS_004", "Warehouse code already exists"),
+    INV_001("INV_001", "Inventory not found"),
+    INV_004("INV_004", "Insufficient available stock"),
+    STA_001("STA_001", "Invalid stock adjustment request"),
+    STA_002("STA_002", "Invalid stock adjustment status transition"),
+    STA_404("STA_404", "Stock adjustment not found"),
+    STF_001("STF_001", "Stock transfer not found"),
+    STF_002("STF_002", "Invalid stock transfer status transition"),
 
     // Location errors
     LOC_001("LOC_001", "Location not found"),

--- a/src/main/java/org/demo/whs/exception/NotFoundException.java
+++ b/src/main/java/org/demo/whs/exception/NotFoundException.java
@@ -4,6 +4,10 @@ import org.springframework.http.HttpStatus;
 
 public class NotFoundException extends BaseException {
     public NotFoundException(String message, ErrorCode errorCode) {
-        super(message, errorCode.getMessage(), HttpStatus.NOT_FOUND);
+        super(errorCode.getCode(), message, HttpStatus.NOT_FOUND);
+    }
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/org/demo/whs/mapper/StockAdjustmentsMapper.java
+++ b/src/main/java/org/demo/whs/mapper/StockAdjustmentsMapper.java
@@ -1,5 +1,6 @@
 package org.demo.whs.mapper;
 
+import org.demo.whs.entity.Inventory;
 import org.demo.whs.entity.StockAdjustments;
 import org.demo.whs.entity.dto.request.StockAdjustments.StockAdjustmentsRequest;
 import org.demo.whs.entity.dto.response.StockAdjustments.StockAdjustmentsResponse;
@@ -14,6 +15,7 @@ public class StockAdjustmentsMapper {
 
     public StockAdjustments toEntity(
             StockAdjustmentsRequest request,
+            Inventory inventory,
             String adjustmentNumber,
             String actorId,
             boolean requiresApproval,
@@ -23,17 +25,19 @@ public class StockAdjustmentsMapper {
             return null;
         }
 
-        BigDecimal adjustmentQty = request.getQuantityAfter().subtract(request.getQuantityBefore());
+        BigDecimal quantityBefore = inventory.getOnHandQuantity();
+        BigDecimal quantityAfter = request.getQuantityAfter();
+        BigDecimal adjustmentQty = quantityAfter.subtract(quantityBefore);
 
         StockAdjustments entity = StockAdjustments.builder()
                 .adjustmentNumber(adjustmentNumber)
                 .inventoryId(request.getInventoryId())
-                .productId(request.getProductId())
-                .warehouseId(request.getWarehouseId())
-                .locationId(request.getLocationId())
-                .batchId(request.getBatchId())
-                .quantityBefore(request.getQuantityBefore())
-                .quantityAfter(request.getQuantityAfter())
+                .productId(inventory.getProductId())
+                .warehouseId(inventory.getWarehouseId())
+                .locationId(inventory.getLocationId())
+                .batchId(inventory.getBatchId())
+                .quantityBefore(quantityBefore)
+                .quantityAfter(quantityAfter)
                 .adjustmentQuantity(adjustmentQty)
                 .reason(request.getReason())
                 .status(status)
@@ -44,7 +48,7 @@ public class StockAdjustmentsMapper {
         if (actorId != null && !actorId.isBlank()) {
             entity.setCreatedBy(actorId);
             entity.setUpdatedBy(actorId);
-            if (!requiresApproval) {
+            if (status == StockAdjustmentsStatus.APPROVED) {
                 entity.setApprovedBy(actorId);
                 entity.setApprovedAt(LocalDateTime.now());
             }

--- a/src/main/java/org/demo/whs/mapper/StockMovementsMapper.java
+++ b/src/main/java/org/demo/whs/mapper/StockMovementsMapper.java
@@ -1,10 +1,78 @@
 package org.demo.whs.mapper;
 
+import org.demo.whs.entity.StockMovements;
+import org.demo.whs.entity.dto.response.StockMovements.StockMovementsResponse;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.demo.whs.entity.enums.StockMovementsType;
 import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 /**
  * Mapper for StockMovements entity to DTOs and vice versa.
  */
 @Component
 public class StockMovementsMapper {
+
+    public StockMovements toEntity(
+            StockMovementsType movementType,
+            String productId,
+            String warehouseId,
+            String locationId,
+            String batchId,
+            BigDecimal quantityChange,
+            BigDecimal quantityBefore,
+            BigDecimal quantityAfter,
+            ReferenceType referenceType,
+            String referenceId,
+            String referenceNumber,
+            String notes,
+            String actorId
+    ) {
+        StockMovements movement = StockMovements.builder()
+                .movementType(movementType)
+                .productId(productId)
+                .warehouseId(warehouseId)
+                .locationId(locationId)
+                .batchId(batchId)
+                .quantityChange(quantityChange)
+                .quantityBefore(quantityBefore)
+                .quantityAfter(quantityAfter)
+                .movementDate(LocalDateTime.now())
+                .referenceType(referenceType)
+                .referenceId(referenceId)
+                .referenceNumber(referenceNumber)
+                .notes(notes)
+                .build();
+
+        movement.setCreatedBy(actorId);
+        movement.setUpdatedBy(actorId);
+        return movement;
+    }
+
+    public StockMovementsResponse toResponse(StockMovements entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return StockMovementsResponse.builder()
+                .id(entity.getId())
+                .movementType(entity.getMovementType())
+                .productId(entity.getProductId())
+                .warehouseId(entity.getWarehouseId())
+                .locationId(entity.getLocationId())
+                .batchId(entity.getBatchId())
+                .quantityChange(entity.getQuantityChange())
+                .quantityBefore(entity.getQuantityBefore())
+                .quantityAfter(entity.getQuantityAfter())
+                .movementDate(entity.getMovementDate())
+                .referenceType(entity.getReferenceType())
+                .referenceId(entity.getReferenceId())
+                .referenceNumber(entity.getReferenceNumber())
+                .notes(entity.getNotes())
+                .createdBy(entity.getCreatedBy())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/org/demo/whs/mapper/StockTransfersMapper.java
+++ b/src/main/java/org/demo/whs/mapper/StockTransfersMapper.java
@@ -1,7 +1,59 @@
 package org.demo.whs.mapper;
 
+import org.demo.whs.entity.StockTransfers;
+import org.demo.whs.entity.dto.request.StockTransfers.StockTransfersRequest;
+import org.demo.whs.entity.dto.response.StockTransfers.StockTransfersResponse;
+import org.demo.whs.entity.enums.StockTransfersStatus;
 import org.springframework.stereotype.Component;
 
 @Component
 public class StockTransfersMapper {
+
+    public StockTransfers toEntity(
+            StockTransfersRequest request,
+            String transferNumber,
+            String actorId
+    ) {
+        StockTransfers entity = StockTransfers.builder()
+                .transferNumber(transferNumber)
+                .productId(request.getProductId())
+                .warehouseId(request.getWarehouseId())
+                .fromLocationId(request.getFromLocationId())
+                .toLocationId(request.getToLocationId())
+                .batchId(request.getBatchId())
+                .quantity(request.getQuantity())
+                .reason(request.getReason())
+                .notes(request.getNotes())
+                .status(StockTransfersStatus.DRAFT)
+                .build();
+
+        entity.setCreatedBy(actorId);
+        entity.setUpdatedBy(actorId);
+        return entity;
+    }
+
+    public StockTransfersResponse toResponse(StockTransfers entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return StockTransfersResponse.builder()
+                .id(entity.getId())
+                .transferNumber(entity.getTransferNumber())
+                .productId(entity.getProductId())
+                .warehouseId(entity.getWarehouseId())
+                .fromLocationId(entity.getFromLocationId())
+                .toLocationId(entity.getToLocationId())
+                .batchId(entity.getBatchId())
+                .quantity(entity.getQuantity())
+                .reason(entity.getReason())
+                .notes(entity.getNotes())
+                .status(entity.getStatus())
+                .completedAt(entity.getCompletedAt())
+                .createdBy(entity.getCreatedBy())
+                .createdAt(entity.getCreatedAt())
+                .updatedBy(entity.getUpdatedBy())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/org/demo/whs/repository/InventoryRepository.java
+++ b/src/main/java/org/demo/whs/repository/InventoryRepository.java
@@ -25,7 +25,7 @@ public interface InventoryRepository extends JpaRepository<Inventory, String> {
         SELECT i FROM Inventory i
         WHERE i.productId = :productId
           AND i.warehouseId = :warehouseId
-          AND i.locationId = :locationId
+          AND ((:locationId IS NULL AND i.locationId IS NULL) OR i.locationId = :locationId)
           AND ((:batchId IS NULL AND i.batchId IS NULL) OR i.batchId = :batchId)
         """)
     Optional<Inventory> findByDimensionForUpdate(

--- a/src/main/java/org/demo/whs/repository/InventoryRepository.java
+++ b/src/main/java/org/demo/whs/repository/InventoryRepository.java
@@ -1,12 +1,37 @@
 package org.demo.whs.repository;
 
 import org.demo.whs.entity.Inventory;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 
 /**
  * Repository interface for managing inventory data.
  */
 @Repository
 public interface InventoryRepository extends JpaRepository<Inventory, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT i FROM Inventory i WHERE i.id = :id")
+    Optional<Inventory> findByIdForUpdate(@Param("id") String id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT i FROM Inventory i
+        WHERE i.productId = :productId
+          AND i.warehouseId = :warehouseId
+          AND i.locationId = :locationId
+          AND ((:batchId IS NULL AND i.batchId IS NULL) OR i.batchId = :batchId)
+        """)
+    Optional<Inventory> findByDimensionForUpdate(
+            @Param("productId") String productId,
+            @Param("warehouseId") String warehouseId,
+            @Param("locationId") String locationId,
+            @Param("batchId") String batchId
+    );
 }

--- a/src/main/java/org/demo/whs/repository/StockAdjustmentsRepository.java
+++ b/src/main/java/org/demo/whs/repository/StockAdjustmentsRepository.java
@@ -4,11 +4,13 @@ import org.demo.whs.entity.StockAdjustments;
 import org.demo.whs.entity.enums.StockAdjustmentsStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +27,10 @@ public interface StockAdjustmentsRepository extends JpaRepository<StockAdjustmen
      * @return an Optional containing the found StockAdjustments, or empty if not found
      */
     Optional<StockAdjustments> findByAdjustmentNumber(String adjustmentNumber);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT sa FROM StockAdjustments sa WHERE sa.id = :id")
+    Optional<StockAdjustments> findByIdForUpdate(@Param("id") String id);
 
     /**
      * Checks if a stock adjustment exists with the given adjustment number.

--- a/src/main/java/org/demo/whs/repository/StockMovementsRepository.java
+++ b/src/main/java/org/demo/whs/repository/StockMovementsRepository.java
@@ -1,6 +1,9 @@
 package org.demo.whs.repository;
 
 import org.demo.whs.entity.StockMovements;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +12,10 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface StockMovementsRepository extends JpaRepository<StockMovements, String> {
+
+    Page<StockMovements> findByReferenceTypeAndReferenceId(
+            ReferenceType referenceType,
+            String referenceId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/org/demo/whs/repository/StockTransfersRepository.java
+++ b/src/main/java/org/demo/whs/repository/StockTransfersRepository.java
@@ -1,12 +1,24 @@
 package org.demo.whs.repository;
 
 import org.demo.whs.entity.StockTransfers;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 
 /**
  * Repository interface for managing stock transfers data.
  */
 @Repository
 public interface StockTransfersRepository extends JpaRepository<StockTransfers, String> {
+
+    boolean existsByTransferNumber(String transferNumber);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT st FROM StockTransfers st WHERE st.id = :id")
+    Optional<StockTransfers> findByIdForUpdate(@Param("id") String id);
 }

--- a/src/main/java/org/demo/whs/service/StockMovementsService.java
+++ b/src/main/java/org/demo/whs/service/StockMovementsService.java
@@ -1,7 +1,22 @@
 package org.demo.whs.service;
 
+import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.entity.dto.response.StockMovements.StockMovementsResponse;
+import org.demo.whs.entity.enums.ReferenceType;
+
 /**
  * Service interface for managing StockMovements operations.
  */
 public interface StockMovementsService {
+
+    StockMovementsResponse getById(String id);
+
+    PageResponse<StockMovementsResponse> getAll(Integer page, Integer size);
+
+    PageResponse<StockMovementsResponse> getByReference(
+            ReferenceType referenceType,
+            String referenceId,
+            Integer page,
+            Integer size
+    );
 }

--- a/src/main/java/org/demo/whs/service/StockTransfersService.java
+++ b/src/main/java/org/demo/whs/service/StockTransfersService.java
@@ -1,7 +1,21 @@
 package org.demo.whs.service;
 
+import org.demo.whs.entity.dto.request.StockTransfers.StockTransfersRequest;
+import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.entity.dto.response.StockTransfers.StockTransfersResponse;
+
 /**
  * Service interface for managing stock transfers operations.
  */
 public interface StockTransfersService {
+
+    StockTransfersResponse createTransfer(StockTransfersRequest request);
+
+    StockTransfersResponse getById(String id);
+
+    PageResponse<StockTransfersResponse> getAll(Integer page, Integer size);
+
+    StockTransfersResponse complete(String id);
+
+    StockTransfersResponse cancel(String id);
 }

--- a/src/main/java/org/demo/whs/service/impl/StockAdjustmentsServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/StockAdjustmentsServiceImpl.java
@@ -37,7 +37,6 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 @Service

--- a/src/main/java/org/demo/whs/service/impl/StockAdjustmentsServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/StockAdjustmentsServiceImpl.java
@@ -1,27 +1,56 @@
 package org.demo.whs.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.entity.Account;
+import org.demo.whs.entity.Inventory;
+import org.demo.whs.entity.StockAdjustments;
+import org.demo.whs.entity.StockMovements;
 import org.demo.whs.entity.dto.request.StockAdjustments.ApproveStockAdjustmentRequest;
 import org.demo.whs.entity.dto.request.StockAdjustments.RejectStockAdjustmentRequest;
 import org.demo.whs.entity.dto.request.StockAdjustments.SearchStockAdjustmentsRequest;
 import org.demo.whs.entity.dto.request.StockAdjustments.StockAdjustmentsRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.StockAdjustments.StockAdjustmentsResponse;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.demo.whs.entity.enums.StockAdjustmentsStatus;
+import org.demo.whs.entity.enums.StockMovementsType;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.exception.NotFoundException;
 import org.demo.whs.mapper.StockAdjustmentsMapper;
+import org.demo.whs.mapper.StockMovementsMapper;
+import org.demo.whs.repository.AccountRepository;
+import org.demo.whs.repository.InventoryRepository;
 import org.demo.whs.repository.StockAdjustmentsRepository;
+import org.demo.whs.repository.StockMovementsRepository;
+import org.demo.whs.security.SecurityUtils;
 import org.demo.whs.service.StockAdjustmentsService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 public class StockAdjustmentsServiceImpl implements StockAdjustmentsService {
 
     private final StockAdjustmentsRepository stockAdjustmentsRepository;
+    private final InventoryRepository inventoryRepository;
+    private final StockMovementsRepository stockMovementsRepository;
+    private final AccountRepository accountRepository;
     private final StockAdjustmentsMapper stockAdjustmentsMapper;
+    private final StockMovementsMapper stockMovementsMapper;
 
     /**
      * Creates a new stock adjustment request.
@@ -30,8 +59,54 @@ public class StockAdjustmentsServiceImpl implements StockAdjustmentsService {
      * @return the created stock adjustment response
      */
     @Override
+    @Transactional
     public StockAdjustmentsResponse createAdjustment(StockAdjustmentsRequest request) {
-        return null;
+        Inventory inventory = getInventoryForUpdate(request.getInventoryId());
+        BigDecimal quantityBefore = inventory.getOnHandQuantity();
+        BigDecimal quantityAfter = request.getQuantityAfter();
+        BigDecimal adjustmentQuantity = quantityAfter.subtract(quantityBefore);
+
+        validateAdjustmentRequest(inventory, quantityAfter, adjustmentQuantity);
+
+        String actorId = getCurrentActorId();
+        boolean requiresApproval = Boolean.TRUE.equals(request.getRequiresApproval());
+        StockAdjustmentsStatus targetStatus = requiresApproval
+                ? StockAdjustmentsStatus.PENDING_APPROVAL
+                : StockAdjustmentsStatus.APPROVED;
+
+        StockAdjustments adjustment = stockAdjustmentsMapper.toEntity(
+                request,
+                inventory,
+                generateAdjustmentNumber(),
+                actorId,
+                requiresApproval,
+                targetStatus
+        );
+        StockAdjustments savedAdjustment = stockAdjustmentsRepository.save(adjustment);
+
+        if (!requiresApproval) {
+            applyInventoryAfterQuantity(inventory, quantityAfter);
+            inventoryRepository.save(inventory);
+
+            StockMovements movement = stockMovementsMapper.toEntity(
+                    adjustmentQuantity.signum() > 0 ? StockMovementsType.ADJUSTMENT_INCREASE : StockMovementsType.ADJUSTMENT_DECREASE,
+                    inventory.getProductId(),
+                    inventory.getWarehouseId(),
+                    inventory.getLocationId(),
+                    inventory.getBatchId(),
+                    adjustmentQuantity,
+                    quantityBefore,
+                    quantityAfter,
+                    ReferenceType.STOCK_ADJUSTMENT,
+                    savedAdjustment.getId(),
+                    savedAdjustment.getAdjustmentNumber(),
+                    request.getNotes(),
+                    actorId
+            );
+            stockMovementsRepository.save(movement);
+        }
+
+        return stockAdjustmentsMapper.toResponse(savedAdjustment);
     }
 
     /**
@@ -41,8 +116,11 @@ public class StockAdjustmentsServiceImpl implements StockAdjustmentsService {
      * @return the stock adjustment response
      */
     @Override
+    @Transactional(readOnly = true)
     public StockAdjustmentsResponse getById(String id) {
-        return null;
+        StockAdjustments adjustment = stockAdjustmentsRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Stock adjustment not found", ErrorCode.STA_404));
+        return stockAdjustmentsMapper.toResponse(adjustment);
     }
 
     /**
@@ -53,8 +131,15 @@ public class StockAdjustmentsServiceImpl implements StockAdjustmentsService {
      * @return a paginated response containing the list of stock adjustments
      */
     @Override
+    @Transactional(readOnly = true)
     public PageResponse<StockAdjustmentsResponse> getAll(Integer page, Integer size) {
-        return null;
+        Pageable pageable = buildPageable(page, size);
+        Page<StockAdjustments> adjustmentPage = stockAdjustmentsRepository.findAll(pageable);
+
+        List<StockAdjustmentsResponse> content = adjustmentPage.getContent().stream()
+                .map(stockAdjustmentsMapper::toResponse)
+                .toList();
+        return PageResponse.from(adjustmentPage, content);
     }
 
     /**
@@ -66,8 +151,24 @@ public class StockAdjustmentsServiceImpl implements StockAdjustmentsService {
      * @return a paginated response containing the search results
      */
     @Override
+    @Transactional(readOnly = true)
     public PageResponse<StockAdjustmentsResponse> search(SearchStockAdjustmentsRequest request, Integer page, Integer size) {
-        return null;
+        Pageable pageable = buildPageable(page, size);
+        Page<StockAdjustments> adjustmentPage = stockAdjustmentsRepository.search(
+                request.getStatus(),
+                request.getProductId(),
+                request.getWarehouseId(),
+                request.getInventoryId(),
+                request.getAdjustmentNumber(),
+                request.getCreatedFrom(),
+                request.getCreatedTo(),
+                pageable
+        );
+
+        List<StockAdjustmentsResponse> content = adjustmentPage.getContent().stream()
+                .map(stockAdjustmentsMapper::toResponse)
+                .toList();
+        return PageResponse.from(adjustmentPage, content);
     }
 
     /**
@@ -78,8 +179,59 @@ public class StockAdjustmentsServiceImpl implements StockAdjustmentsService {
      * @return the updated stock adjustment response after approval
      */
     @Override
+    @Transactional
     public StockAdjustmentsResponse approve(String id, ApproveStockAdjustmentRequest request) {
-        return null;
+        String actorId = getCurrentActorId();
+        StockAdjustments adjustment = stockAdjustmentsRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new NotFoundException("Stock adjustment not found", ErrorCode.STA_404));
+
+        if (adjustment.getStatus() != StockAdjustmentsStatus.PENDING_APPROVAL) {
+            throw new BadRequestException("Adjustment is not in pending status", ErrorCode.STA_002);
+        }
+
+        Inventory inventory = getInventoryForUpdate(adjustment.getInventoryId());
+
+        BigDecimal quantityBefore = inventory.getOnHandQuantity();
+        BigDecimal quantityAfter = adjustment.getQuantityAfter();
+        BigDecimal quantityChange = quantityAfter.subtract(quantityBefore);
+
+        if (quantityAfter.compareTo(BigDecimal.ZERO) < 0
+                || quantityAfter.compareTo(inventory.getReservedQuantity()) < 0
+                || quantityChange.compareTo(BigDecimal.ZERO) == 0) {
+            throw new BadRequestException("Inventory state changed and adjustment is no longer valid", ErrorCode.STA_001);
+        }
+
+        applyInventoryAfterQuantity(inventory, quantityAfter);
+        inventoryRepository.save(inventory);
+
+        adjustment.setStatus(StockAdjustmentsStatus.APPROVED);
+        adjustment.setApprovedBy(actorId);
+        adjustment.setApprovedAt(LocalDateTime.now());
+        adjustment.setRejectionReason(null);
+        adjustment.setUpdatedBy(actorId);
+        if (request != null && request.getApprovalNote() != null && !request.getApprovalNote().isBlank()) {
+            adjustment.setNotes(appendNote(adjustment.getNotes(), "APPROVAL_NOTE", request.getApprovalNote()));
+        }
+        StockAdjustments savedAdjustment = stockAdjustmentsRepository.save(adjustment);
+
+        StockMovements movement = stockMovementsMapper.toEntity(
+                quantityChange.signum() > 0 ? StockMovementsType.ADJUSTMENT_INCREASE : StockMovementsType.ADJUSTMENT_DECREASE,
+                inventory.getProductId(),
+                inventory.getWarehouseId(),
+                inventory.getLocationId(),
+                inventory.getBatchId(),
+                quantityChange,
+                quantityBefore,
+                quantityAfter,
+                ReferenceType.STOCK_ADJUSTMENT,
+                savedAdjustment.getId(),
+                savedAdjustment.getAdjustmentNumber(),
+                request == null ? null : request.getApprovalNote(),
+                actorId
+        );
+        stockMovementsRepository.save(movement);
+
+        return stockAdjustmentsMapper.toResponse(savedAdjustment);
     }
 
     /**
@@ -88,7 +240,90 @@ public class StockAdjustmentsServiceImpl implements StockAdjustmentsService {
      * @return the updated stock adjustment response after rejection
      */
     @Override
+    @Transactional
     public StockAdjustmentsResponse reject(String id, RejectStockAdjustmentRequest request) {
-        return null;
+        String actorId = getCurrentActorId();
+        StockAdjustments adjustment = stockAdjustmentsRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new NotFoundException("Stock adjustment not found", ErrorCode.STA_404));
+
+        if (adjustment.getStatus() != StockAdjustmentsStatus.PENDING_APPROVAL) {
+            throw new BadRequestException("Adjustment is not in pending status", ErrorCode.STA_002);
+        }
+
+        adjustment.setStatus(StockAdjustmentsStatus.REJECTED);
+        adjustment.setRejectionReason(request.getRejectionReason());
+        adjustment.setApprovedBy(actorId);
+        adjustment.setApprovedAt(LocalDateTime.now());
+        adjustment.setUpdatedBy(actorId);
+
+        StockAdjustments savedAdjustment = stockAdjustmentsRepository.save(adjustment);
+        return stockAdjustmentsMapper.toResponse(savedAdjustment);
+    }
+
+    private Inventory getInventoryForUpdate(String inventoryId) {
+        return inventoryRepository.findByIdForUpdate(inventoryId)
+                .orElseThrow(() -> new NotFoundException("Inventory not found", ErrorCode.INV_001));
+    }
+
+    private void validateAdjustmentRequest(Inventory inventory, BigDecimal quantityAfter, BigDecimal adjustmentQuantity) {
+        if (quantityAfter.compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Quantity after must be non-negative", ErrorCode.STA_001);
+        }
+        if (quantityAfter.compareTo(inventory.getReservedQuantity()) < 0) {
+            throw new BadRequestException("Quantity after cannot be lower than reserved quantity", ErrorCode.STA_001);
+        }
+        if (adjustmentQuantity.compareTo(BigDecimal.ZERO) == 0) {
+            throw new BadRequestException("Adjustment quantity cannot be zero", ErrorCode.STA_001);
+        }
+    }
+
+    private void applyInventoryAfterQuantity(Inventory inventory, BigDecimal quantityAfter) {
+        if (quantityAfter.compareTo(inventory.getReservedQuantity()) < 0) {
+            throw new BadRequestException("Quantity after cannot be lower than reserved quantity", ErrorCode.STA_001);
+        }
+        inventory.setOnHandQuantity(quantityAfter);
+        inventory.setLastMovementAt(LocalDateTime.now());
+    }
+
+    private Pageable buildPageable(Integer page, Integer size) {
+        int targetPage = page == null ? 0 : page;
+        int targetSize = size == null ? 10 : size;
+        if (targetPage < 0 || targetSize <= 0 || targetSize > 100) {
+            throw new BadRequestException("Invalid pagination parameters", ErrorCode.COM_001);
+        }
+
+        return PageRequest.of(targetPage, targetSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    private String getCurrentActorId() {
+        String username = SecurityUtils.getCurrentUsername();
+        if (username == null || username.isBlank()) {
+            throw new BadRequestException("Unauthenticated request", ErrorCode.AUTH_002);
+        }
+
+        Account account = accountRepository.findByUsername(username)
+                .orElseThrow(() -> new BadRequestException("User account not found", ErrorCode.AUTH_002));
+        return account.getId();
+    }
+
+    private String generateAdjustmentNumber() {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        for (int i = 0; i < 10; i++) {
+            String candidate = "ADJ-" + timestamp + "-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+            if (!stockAdjustmentsRepository.existsByAdjustmentNumber(candidate)) {
+                return candidate;
+            }
+        }
+        throw new BadRequestException("Unable to generate unique adjustment number", ErrorCode.STA_001);
+    }
+
+    private String appendNote(String existing, String key, String value) {
+        if (value == null || value.isBlank()) {
+            return existing;
+        }
+        if (existing == null || existing.isBlank()) {
+            return key + ": " + value.trim();
+        }
+        return existing + System.lineSeparator() + key + ": " + value.trim();
     }
 }

--- a/src/main/java/org/demo/whs/service/impl/StockAdjustmentsServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/StockAdjustmentsServiceImpl.java
@@ -281,6 +281,7 @@ public class StockAdjustmentsServiceImpl implements StockAdjustmentsService {
             throw new BadRequestException("Quantity after cannot be lower than reserved quantity", ErrorCode.STA_001);
         }
         inventory.setOnHandQuantity(quantityAfter);
+        inventory.setUpdatedBy(getCurrentActorId());
         inventory.setLastMovementAt(LocalDateTime.now());
     }
 

--- a/src/main/java/org/demo/whs/service/impl/StockMovementsServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/StockMovementsServiceImpl.java
@@ -2,8 +2,24 @@ package org.demo.whs.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.entity.StockMovements;
+import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.entity.dto.response.StockMovements.StockMovementsResponse;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.exception.NotFoundException;
+import org.demo.whs.mapper.StockMovementsMapper;
+import org.demo.whs.repository.StockMovementsRepository;
 import org.demo.whs.service.StockMovementsService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * Implementation of StockMovementsService.
@@ -12,4 +28,56 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 public class StockMovementsServiceImpl implements StockMovementsService {
+
+    private final StockMovementsRepository stockMovementsRepository;
+    private final StockMovementsMapper stockMovementsMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public StockMovementsResponse getById(String id) {
+        StockMovements movement = stockMovementsRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Stock movement not found", ErrorCode.COM_004));
+        return stockMovementsMapper.toResponse(movement);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<StockMovementsResponse> getAll(Integer page, Integer size) {
+        Pageable pageable = buildPageable(page, size);
+        Page<StockMovements> movementPage = stockMovementsRepository.findAll(pageable);
+        List<StockMovementsResponse> content = movementPage.getContent().stream()
+                .map(stockMovementsMapper::toResponse)
+                .toList();
+        return PageResponse.from(movementPage, content);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<StockMovementsResponse> getByReference(
+            ReferenceType referenceType,
+            String referenceId,
+            Integer page,
+            Integer size
+    ) {
+        Pageable pageable = buildPageable(page, size);
+        Page<StockMovements> movementPage = stockMovementsRepository.findByReferenceTypeAndReferenceId(
+                referenceType,
+                referenceId,
+                pageable
+        );
+
+        List<StockMovementsResponse> content = movementPage.getContent().stream()
+                .map(stockMovementsMapper::toResponse)
+                .toList();
+        return PageResponse.from(movementPage, content);
+    }
+
+    private Pageable buildPageable(Integer page, Integer size) {
+        int targetPage = page == null ? 0 : page;
+        int targetSize = size == null ? 20 : size;
+        if (targetPage < 0 || targetSize <= 0 || targetSize > 200) {
+            throw new BadRequestException("Invalid pagination parameters", ErrorCode.COM_001);
+        }
+        return PageRequest.of(targetPage, targetSize, Sort.by(Sort.Direction.DESC, "movementDate"));
+    }
 }

--- a/src/main/java/org/demo/whs/service/impl/StockTransfersServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/StockTransfersServiceImpl.java
@@ -2,9 +2,44 @@ package org.demo.whs.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.entity.Account;
+import org.demo.whs.entity.Batch;
+import org.demo.whs.entity.Inventory;
+import org.demo.whs.entity.Locations;
+import org.demo.whs.entity.StockMovements;
+import org.demo.whs.entity.StockTransfers;
+import org.demo.whs.entity.dto.request.StockTransfers.StockTransfersRequest;
+import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.entity.dto.response.StockTransfers.StockTransfersResponse;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.demo.whs.entity.enums.StockMovementsType;
+import org.demo.whs.entity.enums.StockTransfersStatus;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.exception.NotFoundException;
+import org.demo.whs.mapper.StockMovementsMapper;
+import org.demo.whs.mapper.StockTransfersMapper;
+import org.demo.whs.repository.AccountRepository;
+import org.demo.whs.repository.BatchRepository;
+import org.demo.whs.repository.InventoryRepository;
+import org.demo.whs.repository.LocationRepository;
+import org.demo.whs.repository.ProductRepository;
+import org.demo.whs.repository.StockMovementsRepository;
 import org.demo.whs.repository.StockTransfersRepository;
+import org.demo.whs.security.SecurityUtils;
 import org.demo.whs.service.StockTransfersService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -12,5 +47,224 @@ import org.springframework.stereotype.Service;
 public class StockTransfersServiceImpl implements StockTransfersService {
 
     private final StockTransfersRepository stockTransfersRepository;
+    private final InventoryRepository inventoryRepository;
+    private final StockMovementsRepository stockMovementsRepository;
+    private final ProductRepository productRepository;
+    private final LocationRepository locationRepository;
+    private final BatchRepository batchRepository;
+    private final AccountRepository accountRepository;
+    private final StockTransfersMapper stockTransfersMapper;
+    private final StockMovementsMapper stockMovementsMapper;
+
+    @Override
+    @Transactional
+    public StockTransfersResponse createTransfer(StockTransfersRequest request) {
+        validateTransferRequest(request);
+
+        String actorId = getCurrentActorId();
+        StockTransfers transfer = stockTransfersMapper.toEntity(request, generateTransferNumber(), actorId);
+        StockTransfers savedTransfer = stockTransfersRepository.save(transfer);
+        return stockTransfersMapper.toResponse(savedTransfer);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public StockTransfersResponse getById(String id) {
+        StockTransfers transfer = stockTransfersRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Stock transfer not found", ErrorCode.STF_001));
+        return stockTransfersMapper.toResponse(transfer);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<StockTransfersResponse> getAll(Integer page, Integer size) {
+        Pageable pageable = buildPageable(page, size);
+        Page<StockTransfers> transferPage = stockTransfersRepository.findAll(pageable);
+
+        List<StockTransfersResponse> content = transferPage.getContent().stream()
+                .map(stockTransfersMapper::toResponse)
+                .toList();
+        return PageResponse.from(transferPage, content);
+    }
+
+    @Override
+    @Transactional
+    public StockTransfersResponse complete(String id) {
+        String actorId = getCurrentActorId();
+        StockTransfers transfer = stockTransfersRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new NotFoundException("Stock transfer not found", ErrorCode.STF_001));
+
+        if (transfer.getStatus() != StockTransfersStatus.DRAFT) {
+            throw new BadRequestException("Only draft transfer can be completed", ErrorCode.STF_002);
+        }
+
+        Inventory sourceInventory = inventoryRepository.findByDimensionForUpdate(
+                transfer.getProductId(),
+                transfer.getWarehouseId(),
+                transfer.getFromLocationId(),
+                transfer.getBatchId()
+        ).orElseThrow(() -> new NotFoundException("Source inventory not found", ErrorCode.INV_001));
+
+        Inventory destinationInventory = inventoryRepository.findByDimensionForUpdate(
+                transfer.getProductId(),
+                transfer.getWarehouseId(),
+                transfer.getToLocationId(),
+                transfer.getBatchId()
+        ).orElseGet(() -> createDestinationInventory(transfer, actorId));
+
+        BigDecimal quantity = transfer.getQuantity();
+        BigDecimal availableSource = sourceInventory.getOnHandQuantity().subtract(sourceInventory.getReservedQuantity());
+        if (availableSource.compareTo(quantity) < 0) {
+            throw new BadRequestException("Insufficient available stock at source location", ErrorCode.INV_004);
+        }
+
+        BigDecimal sourceBefore = sourceInventory.getOnHandQuantity();
+        BigDecimal sourceAfter = sourceBefore.subtract(quantity);
+        BigDecimal destinationBefore = destinationInventory.getOnHandQuantity();
+        BigDecimal destinationAfter = destinationBefore.add(quantity);
+
+        sourceInventory.setOnHandQuantity(sourceAfter);
+        sourceInventory.setLastMovementAt(LocalDateTime.now());
+        sourceInventory.setUpdatedBy(actorId);
+
+        destinationInventory.setOnHandQuantity(destinationAfter);
+        destinationInventory.setLastMovementAt(LocalDateTime.now());
+        destinationInventory.setUpdatedBy(actorId);
+
+        inventoryRepository.save(sourceInventory);
+        inventoryRepository.save(destinationInventory);
+
+        transfer.setStatus(StockTransfersStatus.COMPLETED);
+        transfer.setCompletedAt(LocalDateTime.now());
+        transfer.setUpdatedBy(actorId);
+        StockTransfers savedTransfer = stockTransfersRepository.save(transfer);
+
+        StockMovements transferOutMovement = stockMovementsMapper.toEntity(
+                StockMovementsType.TRANSFER_OUT,
+                transfer.getProductId(),
+                transfer.getWarehouseId(),
+                transfer.getFromLocationId(),
+                transfer.getBatchId(),
+                quantity.negate(),
+                sourceBefore,
+                sourceAfter,
+                ReferenceType.STOCK_TRANSFER,
+                savedTransfer.getId(),
+                savedTransfer.getTransferNumber(),
+                transfer.getNotes(),
+                actorId
+        );
+        StockMovements transferInMovement = stockMovementsMapper.toEntity(
+                StockMovementsType.TRANSFER_IN,
+                transfer.getProductId(),
+                transfer.getWarehouseId(),
+                transfer.getToLocationId(),
+                transfer.getBatchId(),
+                quantity,
+                destinationBefore,
+                destinationAfter,
+                ReferenceType.STOCK_TRANSFER,
+                savedTransfer.getId(),
+                savedTransfer.getTransferNumber(),
+                transfer.getNotes(),
+                actorId
+        );
+        stockMovementsRepository.save(transferOutMovement);
+        stockMovementsRepository.save(transferInMovement);
+
+        return stockTransfersMapper.toResponse(savedTransfer);
+    }
+
+    @Override
+    @Transactional
+    public StockTransfersResponse cancel(String id) {
+        String actorId = getCurrentActorId();
+        StockTransfers transfer = stockTransfersRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new NotFoundException("Stock transfer not found", ErrorCode.STF_001));
+
+        if (transfer.getStatus() != StockTransfersStatus.DRAFT) {
+            throw new BadRequestException("Only draft transfer can be cancelled", ErrorCode.STF_002);
+        }
+
+        transfer.setStatus(StockTransfersStatus.CANCELLED);
+        transfer.setUpdatedBy(actorId);
+
+        StockTransfers savedTransfer = stockTransfersRepository.save(transfer);
+        return stockTransfersMapper.toResponse(savedTransfer);
+    }
+
+    private void validateTransferRequest(StockTransfersRequest request) {
+        if (request.getFromLocationId().equals(request.getToLocationId())) {
+            throw new BadRequestException("Source and destination locations must be different", ErrorCode.STF_002);
+        }
+
+        if (!productRepository.existsById(request.getProductId())) {
+            throw new BadRequestException("Product not found", ErrorCode.PROD_001);
+        }
+
+        Locations fromLocation = locationRepository.findById(request.getFromLocationId())
+                .orElseThrow(() -> new BadRequestException("Source location not found", ErrorCode.LOC_001));
+        Locations toLocation = locationRepository.findById(request.getToLocationId())
+                .orElseThrow(() -> new BadRequestException("Destination location not found", ErrorCode.LOC_001));
+
+        if (!fromLocation.getWarehouseId().equals(request.getWarehouseId())
+                || !toLocation.getWarehouseId().equals(request.getWarehouseId())) {
+            throw new BadRequestException("Transfer locations must belong to the provided warehouse", ErrorCode.STF_002);
+        }
+
+        if (request.getBatchId() != null && !request.getBatchId().isBlank()) {
+            Batch batch = batchRepository.findById(request.getBatchId())
+                    .orElseThrow(() -> new BadRequestException("Batch not found", ErrorCode.BATCH_001));
+            if (!batch.getProductId().equals(request.getProductId())) {
+                throw new BadRequestException("Batch does not belong to the provided product", ErrorCode.STF_002);
+            }
+        }
+    }
+
+    private Inventory createDestinationInventory(StockTransfers transfer, String actorId) {
+        Inventory inventory = Inventory.builder()
+                .productId(transfer.getProductId())
+                .warehouseId(transfer.getWarehouseId())
+                .locationId(transfer.getToLocationId())
+                .batchId(transfer.getBatchId())
+                .onHandQuantity(BigDecimal.ZERO)
+                .reservedQuantity(BigDecimal.ZERO)
+                .version(0)
+                .build();
+        inventory.setCreatedBy(actorId);
+        inventory.setUpdatedBy(actorId);
+        return inventory;
+    }
+
+    private Pageable buildPageable(Integer page, Integer size) {
+        int targetPage = page == null ? 0 : page;
+        int targetSize = size == null ? 10 : size;
+        if (targetPage < 0 || targetSize <= 0 || targetSize > 100) {
+            throw new BadRequestException("Invalid pagination parameters", ErrorCode.COM_001);
+        }
+        return PageRequest.of(targetPage, targetSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    private String getCurrentActorId() {
+        String username = SecurityUtils.getCurrentUsername();
+        if (username == null || username.isBlank()) {
+            throw new BadRequestException("Unauthenticated request", ErrorCode.AUTH_002);
+        }
+
+        Account account = accountRepository.findByUsername(username)
+                .orElseThrow(() -> new BadRequestException("User account not found", ErrorCode.AUTH_002));
+        return account.getId();
+    }
+
+    private String generateTransferNumber() {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        for (int i = 0; i < 10; i++) {
+            String candidate = "TRF-" + timestamp + "-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+            if (!stockTransfersRepository.existsByTransferNumber(candidate)) {
+                return candidate;
+            }
+        }
+        throw new BadRequestException("Unable to generate unique transfer number", ErrorCode.STF_002);
+    }
 
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -35,6 +35,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
 
   h2:

--- a/src/main/resources/db/migration/V20260404_01__Refactor_inventory_schema_consistency.sql
+++ b/src/main/resources/db/migration/V20260404_01__Refactor_inventory_schema_consistency.sql
@@ -26,6 +26,17 @@ CREATE INDEX idx_inventory_dimension_lookup
 -- ================================
 -- stock_adjustments: tighten quantity and workflow constraints
 -- ================================
+-- Keep approver metadata stable for approved/rejected rows:
+-- ON DELETE SET NULL conflicts with status metadata CHECK in MySQL.
+ALTER TABLE stock_adjustments
+    DROP FOREIGN KEY fk_adjustment_approved_by;
+
+ALTER TABLE stock_adjustments
+    ADD CONSTRAINT fk_adjustment_approved_by
+        FOREIGN KEY (approved_by) REFERENCES accounts (id)
+            ON DELETE RESTRICT
+            ON UPDATE RESTRICT;
+
 ALTER TABLE stock_adjustments
     DROP CHECK chk_adjustment_calculation;
 

--- a/src/main/resources/db/migration/V20260404_01__Refactor_inventory_schema_consistency.sql
+++ b/src/main/resources/db/migration/V20260404_01__Refactor_inventory_schema_consistency.sql
@@ -1,0 +1,78 @@
+-- ============================================================================
+-- Flyway Migration: WHS-70 Inventory Schema Consistency Refactor
+-- Version: V20260404_01
+-- Description: Harden inventory uniqueness and document workflow constraints
+-- ============================================================================
+
+-- ================================
+-- inventory: enforce logical uniqueness when nullable dimensions are present
+-- ================================
+ALTER TABLE inventory
+    DROP INDEX uk_inventory_location;
+
+ALTER TABLE inventory
+    ADD COLUMN location_id_nvl CHAR(36)
+        GENERATED ALWAYS AS (COALESCE(location_id, '00000000-0000-0000-0000-000000000000')) STORED,
+    ADD COLUMN batch_id_nvl CHAR(36)
+        GENERATED ALWAYS AS (COALESCE(batch_id, '00000000-0000-0000-0000-000000000000')) STORED;
+
+ALTER TABLE inventory
+    ADD CONSTRAINT uk_inventory_dimension_normalized
+        UNIQUE (product_id, warehouse_id, location_id_nvl, batch_id_nvl);
+
+CREATE INDEX idx_inventory_dimension_lookup
+    ON inventory (product_id, warehouse_id, location_id, batch_id);
+
+-- ================================
+-- stock_adjustments: tighten quantity and workflow constraints
+-- ================================
+ALTER TABLE stock_adjustments
+    DROP CHECK chk_adjustment_calculation;
+
+ALTER TABLE stock_adjustments
+    ADD CONSTRAINT chk_adjustment_non_negative
+        CHECK (quantity_before >= 0 AND quantity_after >= 0),
+    ADD CONSTRAINT chk_adjustment_calculation
+        CHECK (adjustment_quantity = quantity_after - quantity_before),
+    ADD CONSTRAINT chk_adjustment_non_zero
+        CHECK (adjustment_quantity <> 0),
+    ADD CONSTRAINT chk_adjustment_status_metadata
+        CHECK (
+            (status = 'PENDING_APPROVAL' AND approved_by IS NULL AND approved_at IS NULL AND rejection_reason IS NULL)
+            OR (status = 'APPROVED' AND approved_by IS NOT NULL AND approved_at IS NOT NULL AND rejection_reason IS NULL)
+            OR (status = 'REJECTED' AND approved_by IS NOT NULL AND approved_at IS NOT NULL AND rejection_reason IS NOT NULL)
+        );
+
+CREATE INDEX idx_adjustment_status_created_at
+    ON stock_adjustments (status, created_at);
+
+CREATE INDEX idx_adjustment_inventory_status_created_at
+    ON stock_adjustments (inventory_id, status, created_at);
+
+-- ================================
+-- stock_movements: align schema with application expectations and query paths
+-- ================================
+ALTER TABLE stock_movements
+    MODIFY warehouse_id CHAR(36) NOT NULL,
+    MODIFY location_id CHAR(36) NULL,
+    MODIFY reference_id CHAR(36) NULL,
+    MODIFY reference_number VARCHAR(50) NULL;
+
+CREATE INDEX idx_movement_product_warehouse_date
+    ON stock_movements (product_id, warehouse_id, movement_date DESC);
+
+CREATE INDEX idx_movement_location_date
+    ON stock_movements (location_id, movement_date DESC);
+
+-- ================================
+-- stock_transfers: add indexes for workflow queries
+-- ================================
+CREATE INDEX idx_transfer_status_created_at
+    ON stock_transfers (status, created_at);
+
+CREATE INDEX idx_transfer_inventory_lookup
+    ON stock_transfers (product_id, warehouse_id, from_location_id, batch_id, status);
+
+-- ============================================================================
+-- End of Migration
+-- ============================================================================

--- a/src/main/resources/db/migration/V20260404_02__Seed_inventory_operations_dev_data.sql
+++ b/src/main/resources/db/migration/V20260404_02__Seed_inventory_operations_dev_data.sql
@@ -24,11 +24,11 @@ SET @seed_admin_id := COALESCE(
 -- ================================
 INSERT INTO units_of_measure (id, code, name, description, type, created_by, updated_by)
 VALUES
-    ('91000000-0000-0000-0000-000000000001', 'UOM-DEV-001', 'Piece',  'Count by piece',   'COUNT',  @seed_admin_id, @seed_admin_id),
-    ('91000000-0000-0000-0000-000000000002', 'UOM-DEV-002', 'Box',    'Count by box',     'COUNT',  @seed_admin_id, @seed_admin_id),
-    ('91000000-0000-0000-0000-000000000003', 'UOM-DEV-003', 'Kg',     'Weight in kg',     'WEIGHT', @seed_admin_id, @seed_admin_id),
-    ('91000000-0000-0000-0000-000000000004', 'UOM-DEV-004', 'Meter',  'Length in meter',  'LENGTH', @seed_admin_id, @seed_admin_id),
-    ('91000000-0000-0000-0000-000000000005', 'UOM-DEV-005', 'Liter',  'Volume in liter',  'VOLUME', @seed_admin_id, @seed_admin_id)
+    ('91000000-0000-0000-0000-000000000001', 'UOMD001', 'Piece',  'Count by piece',   'COUNT',  @seed_admin_id, @seed_admin_id),
+    ('91000000-0000-0000-0000-000000000002', 'UOMD002', 'Box',    'Count by box',     'COUNT',  @seed_admin_id, @seed_admin_id),
+    ('91000000-0000-0000-0000-000000000003', 'UOMD003', 'Kg',     'Weight in kg',     'WEIGHT', @seed_admin_id, @seed_admin_id),
+    ('91000000-0000-0000-0000-000000000004', 'UOMD004', 'Meter',  'Length in meter',  'LENGTH', @seed_admin_id, @seed_admin_id),
+    ('91000000-0000-0000-0000-000000000005', 'UOMD005', 'Liter',  'Volume in liter',  'VOLUME', @seed_admin_id, @seed_admin_id)
 ON DUPLICATE KEY UPDATE id = id;
 
 INSERT INTO categories (id, code, name, description, status, created_by, updated_by)

--- a/src/main/resources/db/migration/V20260404_02__Seed_inventory_operations_dev_data.sql
+++ b/src/main/resources/db/migration/V20260404_02__Seed_inventory_operations_dev_data.sql
@@ -1,0 +1,151 @@
+-- ============================================================================
+-- Flyway Migration: Seed Inventory Operations Dev Data
+-- Version: V20260404_02
+-- Description: Seed 5 records per inventory operations table for local dev test
+-- ============================================================================
+
+-- Ensure there is at least one account to reference in audit fields.
+INSERT INTO accounts (id, username, password, status)
+SELECT
+    '99000000-0000-0000-0000-000000000900',
+    'dev_seed_admin',
+    '$2a$10$2FrGg2/7Rtr7lQWRZ9UNV..WQblwoUUgJgOxWYnhP.okeEd3Jo5si',
+    'ACTIVE'
+WHERE NOT EXISTS (SELECT 1 FROM accounts);
+
+SET @seed_admin_id := COALESCE(
+    (SELECT id FROM accounts WHERE username = 'admin' LIMIT 1),
+    (SELECT id FROM accounts WHERE username = 'dev_seed_admin' LIMIT 1),
+    (SELECT id FROM accounts ORDER BY created_at LIMIT 1)
+);
+
+-- ================================
+-- Master data for FK dependencies
+-- ================================
+INSERT INTO units_of_measure (id, code, name, description, type, created_by, updated_by)
+VALUES
+    ('91000000-0000-0000-0000-000000000001', 'UOM-DEV-001', 'Piece',  'Count by piece',   'COUNT',  @seed_admin_id, @seed_admin_id),
+    ('91000000-0000-0000-0000-000000000002', 'UOM-DEV-002', 'Box',    'Count by box',     'COUNT',  @seed_admin_id, @seed_admin_id),
+    ('91000000-0000-0000-0000-000000000003', 'UOM-DEV-003', 'Kg',     'Weight in kg',     'WEIGHT', @seed_admin_id, @seed_admin_id),
+    ('91000000-0000-0000-0000-000000000004', 'UOM-DEV-004', 'Meter',  'Length in meter',  'LENGTH', @seed_admin_id, @seed_admin_id),
+    ('91000000-0000-0000-0000-000000000005', 'UOM-DEV-005', 'Liter',  'Volume in liter',  'VOLUME', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO categories (id, code, name, description, status, created_by, updated_by)
+VALUES
+    ('92000000-0000-0000-0000-000000000001', 'CAT-DEV-001', 'Dev Category 1', 'Dev category seed 1', 'ACTIVE', @seed_admin_id, @seed_admin_id),
+    ('92000000-0000-0000-0000-000000000002', 'CAT-DEV-002', 'Dev Category 2', 'Dev category seed 2', 'ACTIVE', @seed_admin_id, @seed_admin_id),
+    ('92000000-0000-0000-0000-000000000003', 'CAT-DEV-003', 'Dev Category 3', 'Dev category seed 3', 'ACTIVE', @seed_admin_id, @seed_admin_id),
+    ('92000000-0000-0000-0000-000000000004', 'CAT-DEV-004', 'Dev Category 4', 'Dev category seed 4', 'ACTIVE', @seed_admin_id, @seed_admin_id),
+    ('92000000-0000-0000-0000-000000000005', 'CAT-DEV-005', 'Dev Category 5', 'Dev category seed 5', 'ACTIVE', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO warehouses (id, code, name, city, country, type, status, capacity, created_by, updated_by)
+VALUES
+    ('93000000-0000-0000-0000-000000000001', 'WH-DEV-001', 'Dev Warehouse 1', 'Ho Chi Minh', 'VN', 'MAIN',      'ACTIVE', 10000.00, @seed_admin_id, @seed_admin_id),
+    ('93000000-0000-0000-0000-000000000002', 'WH-DEV-002', 'Dev Warehouse 2', 'Ha Noi',      'VN', 'SATELLITE', 'ACTIVE',  8000.00, @seed_admin_id, @seed_admin_id),
+    ('93000000-0000-0000-0000-000000000003', 'WH-DEV-003', 'Dev Warehouse 3', 'Da Nang',     'VN', 'TRANSIT',   'ACTIVE',  6000.00, @seed_admin_id, @seed_admin_id),
+    ('93000000-0000-0000-0000-000000000004', 'WH-DEV-004', 'Dev Warehouse 4', 'Can Tho',     'VN', 'RETURN',    'ACTIVE',  4000.00, @seed_admin_id, @seed_admin_id),
+    ('93000000-0000-0000-0000-000000000005', 'WH-DEV-005', 'Dev Warehouse 5', 'Hai Phong',   'VN', 'SATELLITE', 'ACTIVE',  5000.00, @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO locations (id, warehouse_id, code, name, zone, type, capacity, status, notes, created_by, updated_by)
+VALUES
+    ('94000000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', 'LOC-DEV-001', 'Dev Location 1', 'A', 'STORAGE', 1000.00, 'ACTIVE', 'Seed location 1', @seed_admin_id, @seed_admin_id),
+    ('94000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', 'LOC-DEV-002', 'Dev Location 2', 'A', 'PICKING',  900.00, 'ACTIVE', 'Seed location 2', @seed_admin_id, @seed_admin_id),
+    ('94000000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', 'LOC-DEV-003', 'Dev Location 3', 'B', 'PACKING',  800.00, 'ACTIVE', 'Seed location 3', @seed_admin_id, @seed_admin_id),
+    ('94000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', 'LOC-DEV-004', 'Dev Location 4', 'B', 'STAGING',  700.00, 'ACTIVE', 'Seed location 4', @seed_admin_id, @seed_admin_id),
+    ('94000000-0000-0000-0000-000000000005', '93000000-0000-0000-0000-000000000001', 'LOC-DEV-005', 'Dev Location 5', 'C', 'RETURN',   600.00, 'ACTIVE', 'Seed location 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO products
+(
+    id, sku, name, description, category_id, uom_id, status,
+    min_stock_level, max_stock_level, reorder_point, cost_price, selling_price,
+    requires_batch_tracking, created_by, updated_by
+)
+VALUES
+    ('95000000-0000-0000-0000-000000000001', 'SKU-DEV-001', 'Dev Product 1', 'Seed product 1', '92000000-0000-0000-0000-000000000001', '91000000-0000-0000-0000-000000000001', 'ACTIVE',  20.00, 300.00,  50.00, 10.00, 14.00, TRUE,  @seed_admin_id, @seed_admin_id),
+    ('95000000-0000-0000-0000-000000000002', 'SKU-DEV-002', 'Dev Product 2', 'Seed product 2', '92000000-0000-0000-0000-000000000002', '91000000-0000-0000-0000-000000000002', 'ACTIVE',  10.00, 250.00,  40.00, 12.00, 18.00, TRUE,  @seed_admin_id, @seed_admin_id),
+    ('95000000-0000-0000-0000-000000000003', 'SKU-DEV-003', 'Dev Product 3', 'Seed product 3', '92000000-0000-0000-0000-000000000003', '91000000-0000-0000-0000-000000000003', 'ACTIVE',  15.00, 200.00,  35.00,  8.00, 12.00, TRUE,  @seed_admin_id, @seed_admin_id),
+    ('95000000-0000-0000-0000-000000000004', 'SKU-DEV-004', 'Dev Product 4', 'Seed product 4', '92000000-0000-0000-0000-000000000004', '91000000-0000-0000-0000-000000000004', 'ACTIVE',  25.00, 400.00,  60.00, 20.00, 28.00, TRUE,  @seed_admin_id, @seed_admin_id),
+    ('95000000-0000-0000-0000-000000000005', 'SKU-DEV-005', 'Dev Product 5', 'Seed product 5', '92000000-0000-0000-0000-000000000005', '91000000-0000-0000-0000-000000000005', 'ACTIVE',  30.00, 500.00,  80.00, 30.00, 42.00, TRUE,  @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO batches
+(
+    id, batch_number, product_id, manufacturing_date, expiry_date, status,
+    supplier_batch_number, notes, created_by, updated_by
+)
+VALUES
+    ('96000000-0000-0000-0000-000000000001', 'BATCH-DEV-001', '95000000-0000-0000-0000-000000000001', '2026-01-01', '2027-01-01', 'AVAILABLE', 'SUP-BATCH-001', 'Seed batch 1', @seed_admin_id, @seed_admin_id),
+    ('96000000-0000-0000-0000-000000000002', 'BATCH-DEV-002', '95000000-0000-0000-0000-000000000002', '2026-01-02', '2027-01-02', 'AVAILABLE', 'SUP-BATCH-002', 'Seed batch 2', @seed_admin_id, @seed_admin_id),
+    ('96000000-0000-0000-0000-000000000003', 'BATCH-DEV-003', '95000000-0000-0000-0000-000000000003', '2026-01-03', '2027-01-03', 'AVAILABLE', 'SUP-BATCH-003', 'Seed batch 3', @seed_admin_id, @seed_admin_id),
+    ('96000000-0000-0000-0000-000000000004', 'BATCH-DEV-004', '95000000-0000-0000-0000-000000000004', '2026-01-04', '2027-01-04', 'AVAILABLE', 'SUP-BATCH-004', 'Seed batch 4', @seed_admin_id, @seed_admin_id),
+    ('96000000-0000-0000-0000-000000000005', 'BATCH-DEV-005', '95000000-0000-0000-0000-000000000005', '2026-01-05', '2027-01-05', 'AVAILABLE', 'SUP-BATCH-005', 'Seed batch 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ================================
+-- Inventory operations module data
+-- 5 records per table
+-- ================================
+INSERT INTO inventory
+(
+    id, product_id, warehouse_id, location_id, batch_id,
+    on_hand_quantity, reserved_quantity, version, last_movement_at,
+    created_by, updated_by
+)
+VALUES
+    ('97000000-0000-0000-0000-000000000001', '95000000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000001', 110.00, 10.00, 0, NOW(), @seed_admin_id, @seed_admin_id),
+    ('97000000-0000-0000-0000-000000000002', '95000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000002', '96000000-0000-0000-0000-000000000002',  95.00,  5.00, 0, NOW(), @seed_admin_id, @seed_admin_id),
+    ('97000000-0000-0000-0000-000000000003', '95000000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000003', '96000000-0000-0000-0000-000000000003',  60.00, 10.00, 0, NOW(), @seed_admin_id, @seed_admin_id),
+    ('97000000-0000-0000-0000-000000000004', '95000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000004', '96000000-0000-0000-0000-000000000004', 170.00, 20.00, 0, NOW(), @seed_admin_id, @seed_admin_id),
+    ('97000000-0000-0000-0000-000000000005', '95000000-0000-0000-0000-000000000005', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000005', '96000000-0000-0000-0000-000000000005', 180.00, 15.00, 0, NOW(), @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO stock_adjustments
+(
+    id, adjustment_number, inventory_id, product_id, warehouse_id, location_id, batch_id,
+    quantity_before, quantity_after, adjustment_quantity, reason, status,
+    notes, requires_approval, approved_by, approved_at, rejection_reason,
+    created_by, updated_by
+)
+VALUES
+    ('98000000-0000-0000-0000-000000000001', 'ADJ-DEV-0001', '97000000-0000-0000-0000-000000000001', '95000000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000001', 110.00, 100.00, -10.00, 'DAMAGE',        'PENDING_APPROVAL', 'Dev pending adjustment 1', TRUE,  NULL,          NULL, NULL,                         @seed_admin_id, @seed_admin_id),
+    ('98000000-0000-0000-0000-000000000002', 'ADJ-DEV-0002', '97000000-0000-0000-0000-000000000002', '95000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000002', '96000000-0000-0000-0000-000000000002',  80.00,  95.00,  15.00, 'COUNT_ERROR',   'APPROVED',         'Dev approved adjustment 2', TRUE,  @seed_admin_id, NOW(), NULL,                         @seed_admin_id, @seed_admin_id),
+    ('98000000-0000-0000-0000-000000000003', 'ADJ-DEV-0003', '97000000-0000-0000-0000-000000000003', '95000000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000003', '96000000-0000-0000-0000-000000000003',  70.00,  60.00, -10.00, 'QUALITY_ISSUE', 'REJECTED',         'Dev rejected adjustment 3', TRUE,  @seed_admin_id, NOW(), 'Rejected for missing proof', @seed_admin_id, @seed_admin_id),
+    ('98000000-0000-0000-0000-000000000004', 'ADJ-DEV-0004', '97000000-0000-0000-0000-000000000004', '95000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000004', '96000000-0000-0000-0000-000000000004', 150.00, 170.00,  20.00, 'SYSTEM_ERROR',  'APPROVED',         'Dev auto-approved adj 4',   FALSE, @seed_admin_id, NOW(), NULL,                         @seed_admin_id, @seed_admin_id),
+    ('98000000-0000-0000-0000-000000000005', 'ADJ-DEV-0005', '97000000-0000-0000-0000-000000000005', '95000000-0000-0000-0000-000000000005', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000005', '96000000-0000-0000-0000-000000000005', 200.00, 180.00, -20.00, 'THEFT',         'PENDING_APPROVAL', 'Dev pending adjustment 5', TRUE,  NULL,          NULL, NULL,                         @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO stock_transfers
+(
+    id, transfer_number, product_id, warehouse_id, batch_id,
+    from_location_id, to_location_id, quantity, reason, notes,
+    status, completed_at, created_by, updated_by
+)
+VALUES
+    ('98100000-0000-0000-0000-000000000001', 'TRF-DEV-0001', '95000000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000002',  5.00, 'REORG',         'Dev draft transfer 1',     'DRAFT',     NULL,  @seed_admin_id, @seed_admin_id),
+    ('98100000-0000-0000-0000-000000000002', 'TRF-DEV-0002', '95000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000002', '94000000-0000-0000-0000-000000000002', '94000000-0000-0000-0000-000000000003',  8.00, 'PICKING_PREP',  'Dev completed transfer 2', 'COMPLETED', NOW(), @seed_admin_id, @seed_admin_id),
+    ('98100000-0000-0000-0000-000000000003', 'TRF-DEV-0003', '95000000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000003', '94000000-0000-0000-0000-000000000003', '94000000-0000-0000-0000-000000000004',  6.00, 'OVERFLOW',      'Dev cancelled transfer 3', 'CANCELLED', NULL,  @seed_admin_id, @seed_admin_id),
+    ('98100000-0000-0000-0000-000000000004', 'TRF-DEV-0004', '95000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000004', '94000000-0000-0000-0000-000000000004', '94000000-0000-0000-0000-000000000005', 10.00, 'CONSOLIDATION', 'Dev completed transfer 4', 'COMPLETED', NOW(), @seed_admin_id, @seed_admin_id),
+    ('98100000-0000-0000-0000-000000000005', 'TRF-DEV-0005', '95000000-0000-0000-0000-000000000005', '93000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000005', '94000000-0000-0000-0000-000000000005', '94000000-0000-0000-0000-000000000001',  4.00, 'OTHER',         'Dev draft transfer 5',     'DRAFT',     NULL,  @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO stock_movements
+(
+    id, movement_type, product_id, warehouse_id, location_id, batch_id,
+    quantity_change, quantity_before, quantity_after, movement_date,
+    reference_type, reference_id, reference_number, notes, created_by, updated_by
+)
+VALUES
+    ('98200000-0000-0000-0000-000000000001', 'ADJUSTMENT_INCREASE', '95000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000002', '96000000-0000-0000-0000-000000000002',  15.00,  80.00,  95.00, NOW(), 'STOCK_ADJUSTMENT', '98000000-0000-0000-0000-000000000002', 'ADJ-DEV-0002', 'Seed movement for approved adjustment', @seed_admin_id, @seed_admin_id),
+    ('98200000-0000-0000-0000-000000000002', 'TRANSFER_OUT',         '95000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000002', '96000000-0000-0000-0000-000000000002',  -8.00,  95.00,  87.00, NOW(), 'STOCK_TRANSFER',   '98100000-0000-0000-0000-000000000002', 'TRF-DEV-0002', 'Seed movement transfer out',            @seed_admin_id, @seed_admin_id),
+    ('98200000-0000-0000-0000-000000000003', 'TRANSFER_IN',          '95000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000003', '96000000-0000-0000-0000-000000000002',   8.00,  30.00,  38.00, NOW(), 'STOCK_TRANSFER',   '98100000-0000-0000-0000-000000000002', 'TRF-DEV-0002', 'Seed movement transfer in',             @seed_admin_id, @seed_admin_id),
+    ('98200000-0000-0000-0000-000000000004', 'ADJUSTMENT_INCREASE', '95000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000004', '96000000-0000-0000-0000-000000000004',  20.00, 150.00, 170.00, NOW(), 'STOCK_ADJUSTMENT', '98000000-0000-0000-0000-000000000004', 'ADJ-DEV-0004', 'Seed movement for auto-approved adj',   @seed_admin_id, @seed_admin_id),
+    ('98200000-0000-0000-0000-000000000005', 'TRANSFER_OUT',         '95000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000004', '96000000-0000-0000-0000-000000000004', -10.00, 170.00, 160.00, NOW(), 'STOCK_TRANSFER',   '98100000-0000-0000-0000-000000000004', 'TRF-DEV-0004', 'Seed movement transfer out',            @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ============================================================================
+-- End of Migration
+-- ============================================================================

--- a/src/main/resources/db/migration/V20260404_03__Seed_full_project_dev_data.sql
+++ b/src/main/resources/db/migration/V20260404_03__Seed_full_project_dev_data.sql
@@ -1,0 +1,295 @@
+-- ============================================================================
+-- Flyway Migration: Seed Full Project Dev Data
+-- Version: V20260404_03
+-- Description: Seed remaining project tables for local development/testing
+-- ============================================================================
+
+SET @seed_password := '$2a$10$2FrGg2/7Rtr7lQWRZ9UNV..WQblwoUUgJgOxWYnhP.okeEd3Jo5si';
+
+-- Ensure USER role exists (ADMIN is created in earlier migrations).
+INSERT INTO roles (id, code, name, description)
+SELECT
+    'A1000000-0000-0000-0000-000000000001',
+    'ROLE_USER',
+    'USER',
+    'Standard user role'
+WHERE NOT EXISTS (
+    SELECT 1 FROM roles WHERE name = 'USER'
+);
+
+SET @role_admin_id := (SELECT id FROM roles WHERE name = 'ADMIN' LIMIT 1);
+SET @role_user_id  := (SELECT id FROM roles WHERE name = 'USER' LIMIT 1);
+
+SET @seed_admin_id := COALESCE(
+    (SELECT id FROM accounts WHERE username = 'admin' LIMIT 1),
+    (SELECT id FROM accounts WHERE username = 'dev_seed_admin' LIMIT 1),
+    (SELECT id FROM accounts ORDER BY created_at LIMIT 1)
+);
+
+-- ================================
+-- Accounts + RBAC
+-- ================================
+INSERT INTO accounts (id, username, password, status)
+VALUES
+    ('A2000000-0000-0000-0000-000000000001', 'emp.dev01', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000002', 'emp.dev02', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000003', 'emp.dev03', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000004', 'emp.dev04', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000005', 'emp.dev05', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000006', 'cust.dev01', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000007', 'cust.dev02', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000008', 'cust.dev03', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000009', 'cust.dev04', @seed_password, 'ACTIVE'),
+    ('A2000000-0000-0000-0000-000000000010', 'cust.dev05', @seed_password, 'ACTIVE')
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO permissions (id, code, name, description)
+VALUES
+    ('A3000000-0000-0000-0000-000000000001', 'PERM_INV_READ',       'Inventory Read',      'Can read inventory data'),
+    ('A3000000-0000-0000-0000-000000000002', 'PERM_INV_WRITE',      'Inventory Write',     'Can update inventory data'),
+    ('A3000000-0000-0000-0000-000000000003', 'PERM_ORDER_READ',     'Order Read',          'Can read order data'),
+    ('A3000000-0000-0000-0000-000000000004', 'PERM_ORDER_WRITE',    'Order Write',         'Can update order data'),
+    ('A3000000-0000-0000-0000-000000000005', 'PERM_REPORT_EXPORT',  'Report Export',       'Can export reports')
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT IGNORE INTO account_roles (account_id, role_id)
+SELECT id, @role_user_id
+FROM accounts
+WHERE username IN (
+    'emp.dev01', 'emp.dev02', 'emp.dev03', 'emp.dev04', 'emp.dev05',
+    'cust.dev01', 'cust.dev02', 'cust.dev03', 'cust.dev04', 'cust.dev05'
+);
+
+INSERT IGNORE INTO account_roles (account_id, role_id)
+SELECT @seed_admin_id, @role_admin_id
+WHERE @seed_admin_id IS NOT NULL AND @role_admin_id IS NOT NULL;
+
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT @role_admin_id, p.id
+FROM permissions p
+WHERE @role_admin_id IS NOT NULL;
+
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT @role_user_id, p.id
+FROM permissions p
+WHERE @role_user_id IS NOT NULL
+  AND p.code IN ('PERM_INV_READ', 'PERM_ORDER_READ', 'PERM_REPORT_EXPORT');
+
+-- ================================
+-- User Profiles
+-- ================================
+INSERT INTO user_profiles
+(
+    id, account_id, first_name, last_name, email, phone_number, address, date_of_birth,
+    created_by, updated_by
+)
+VALUES
+    ('A4000000-0000-0000-0000-000000000001', 'A2000000-0000-0000-0000-000000000001', 'Emp',  'Dev01',  'emp.dev01@whs.local',  '0901000001', 'HCM City', '1994-01-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000002', 'A2000000-0000-0000-0000-000000000002', 'Emp',  'Dev02',  'emp.dev02@whs.local',  '0901000002', 'HCM City', '1994-02-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000003', 'A2000000-0000-0000-0000-000000000003', 'Emp',  'Dev03',  'emp.dev03@whs.local',  '0901000003', 'HCM City', '1994-03-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000004', 'A2000000-0000-0000-0000-000000000004', 'Emp',  'Dev04',  'emp.dev04@whs.local',  '0901000004', 'HCM City', '1994-04-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000005', 'A2000000-0000-0000-0000-000000000005', 'Emp',  'Dev05',  'emp.dev05@whs.local',  '0901000005', 'HCM City', '1994-05-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000006', 'A2000000-0000-0000-0000-000000000006', 'Cust', 'Dev01',  'cust.dev01@whs.local', '0902000001', 'Ha Noi',   '1996-01-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000007', 'A2000000-0000-0000-0000-000000000007', 'Cust', 'Dev02',  'cust.dev02@whs.local', '0902000002', 'Da Nang',  '1996-02-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000008', 'A2000000-0000-0000-0000-000000000008', 'Cust', 'Dev03',  'cust.dev03@whs.local', '0902000003', 'Can Tho',  '1996-03-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000009', 'A2000000-0000-0000-0000-000000000009', 'Cust', 'Dev04',  'cust.dev04@whs.local', '0902000004', 'Hue',      '1996-04-01', @seed_admin_id, @seed_admin_id),
+    ('A4000000-0000-0000-0000-000000000010', 'A2000000-0000-0000-0000-000000000010', 'Cust', 'Dev05',  'cust.dev05@whs.local', '0902000005', 'Hai Phong','1996-05-01', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ================================
+-- Business Partners
+-- ================================
+INSERT INTO business_partners
+(
+    id, code, name, type, contact_person, email, phone, address, city, country,
+    tax_id, payment_terms, credit_limit, status, notes, created_by, updated_by
+)
+VALUES
+    ('A5000000-0000-0000-0000-000000000001', 'BP-DEV-001', 'Dev Supplier 1', 'SUPPLIER', 'Nguyen A', 'supplier1@dev.local', '0911000001', 'Address 1', 'HCM City', 'VN', 'TAX-SUP-001', 'NET 30',  50000.00, 'ACTIVE', 'Seed supplier 1', @seed_admin_id, @seed_admin_id),
+    ('A5000000-0000-0000-0000-000000000002', 'BP-DEV-002', 'Dev Supplier 2', 'SUPPLIER', 'Nguyen B', 'supplier2@dev.local', '0911000002', 'Address 2', 'Ha Noi',   'VN', 'TAX-SUP-002', 'NET 15',  30000.00, 'ACTIVE', 'Seed supplier 2', @seed_admin_id, @seed_admin_id),
+    ('A5000000-0000-0000-0000-000000000003', 'BP-DEV-003', 'Dev Customer 1', 'CUSTOMER', 'Tran C',   'customer1@dev.local', '0912000001', 'Address 3', 'Da Nang',  'VN', 'TAX-CUS-001', 'NET 07',  20000.00, 'ACTIVE', 'Seed customer 1', @seed_admin_id, @seed_admin_id),
+    ('A5000000-0000-0000-0000-000000000004', 'BP-DEV-004', 'Dev Customer 2', 'CUSTOMER', 'Tran D',   'customer2@dev.local', '0912000002', 'Address 4', 'Can Tho',  'VN', 'TAX-CUS-002', 'NET 07',  15000.00, 'ACTIVE', 'Seed customer 2', @seed_admin_id, @seed_admin_id),
+    ('A5000000-0000-0000-0000-000000000005', 'BP-DEV-005', 'Dev Partner 3',  'BOTH',     'Le E',     'partner3@dev.local',  '0913000003', 'Address 5', 'Hai Phong','VN', 'TAX-BTH-003', 'NET 30',  40000.00, 'ACTIVE', 'Seed both type',  @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ================================
+-- Employees
+-- ================================
+INSERT INTO employees
+(
+    id, account_id, employee_code, department, position, hire_date, termination_date,
+    salary_grade, warehouse_id, status, created_by, updated_by
+)
+VALUES
+    ('A6000000-0000-0000-0000-000000000001', 'A2000000-0000-0000-0000-000000000001', 'EMP-DEV-001', 'Inbound',  'Operator',   '2025-01-10', NULL, 'G5', '93000000-0000-0000-0000-000000000001', 'ACTIVE',   @seed_admin_id, @seed_admin_id),
+    ('A6000000-0000-0000-0000-000000000002', 'A2000000-0000-0000-0000-000000000002', 'EMP-DEV-002', 'Outbound', 'Picker',     '2025-01-11', NULL, 'G4', '93000000-0000-0000-0000-000000000001', 'ACTIVE',   @seed_admin_id, @seed_admin_id),
+    ('A6000000-0000-0000-0000-000000000003', 'A2000000-0000-0000-0000-000000000003', 'EMP-DEV-003', 'Inventory','Controller', '2025-01-12', NULL, 'G6', '93000000-0000-0000-0000-000000000001', 'ON_LEAVE', @seed_admin_id, @seed_admin_id),
+    ('A6000000-0000-0000-0000-000000000004', 'A2000000-0000-0000-0000-000000000004', 'EMP-DEV-004', 'Inbound',  'Supervisor', '2025-01-13', NULL, 'G7', '93000000-0000-0000-0000-000000000001', 'ACTIVE',   @seed_admin_id, @seed_admin_id),
+    ('A6000000-0000-0000-0000-000000000005', 'A2000000-0000-0000-0000-000000000005', 'EMP-DEV-005', 'QA',       'Inspector',  '2025-01-14', NULL, 'G5', '93000000-0000-0000-0000-000000000001', 'ACTIVE',   @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ================================
+-- Customers
+-- ================================
+INSERT INTO customers
+(
+    id, account_id, customer_code, credit_limit, loyalty_points, customer_tier, tax_id,
+    business_partner_id, status, email_verified, notes, created_by, updated_by
+)
+VALUES
+    ('A7000000-0000-0000-0000-000000000001', 'A2000000-0000-0000-0000-000000000006', 'CUST-DEV-001',  5000.00,  100, 'STANDARD', 'CUS-TAX-001', 'A5000000-0000-0000-0000-000000000003', 'ACTIVE',    TRUE,  'Seed customer profile 1', @seed_admin_id, @seed_admin_id),
+    ('A7000000-0000-0000-0000-000000000002', 'A2000000-0000-0000-0000-000000000007', 'CUST-DEV-002', 10000.00,  250, 'SILVER',   'CUS-TAX-002', 'A5000000-0000-0000-0000-000000000004', 'ACTIVE',    TRUE,  'Seed customer profile 2', @seed_admin_id, @seed_admin_id),
+    ('A7000000-0000-0000-0000-000000000003', 'A2000000-0000-0000-0000-000000000008', 'CUST-DEV-003', 15000.00,  500, 'GOLD',     'CUS-TAX-003', 'A5000000-0000-0000-0000-000000000005', 'ACTIVE',    TRUE,  'Seed customer profile 3', @seed_admin_id, @seed_admin_id),
+    ('A7000000-0000-0000-0000-000000000004', 'A2000000-0000-0000-0000-000000000009', 'CUST-DEV-004', 25000.00,  900, 'PLATINUM', 'CUS-TAX-004', NULL,                                    'SUSPENDED', FALSE, 'Seed customer profile 4', @seed_admin_id, @seed_admin_id),
+    ('A7000000-0000-0000-0000-000000000005', 'A2000000-0000-0000-0000-000000000010', 'CUST-DEV-005',  8000.00,   50, 'STANDARD', 'CUS-TAX-005', NULL,                                    'ACTIVE',    FALSE, 'Seed customer profile 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ================================
+-- Inbound Operations
+-- ================================
+INSERT INTO purchase_orders
+(
+    id, purchase_order_number, supplier_id, warehouse_id, order_date, expected_delivery_date, status,
+    sub_total, tax_amount, total_amount, currency, payment_terms, notes, confirmed_at, confirmed_by,
+    created_by, updated_by
+)
+VALUES
+    ('A8000000-0000-0000-0000-000000000001', 'PO-DEV-0001', 'A5000000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', '2026-03-01', '2026-03-05', 'DRAFT',              500.00, 50.00, 550.00, 'USD', 'NET 30', 'Dev PO 1', NULL, NULL, @seed_admin_id, @seed_admin_id),
+    ('A8000000-0000-0000-0000-000000000002', 'PO-DEV-0002', 'A5000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '2026-03-02', '2026-03-06', 'CONFIRMED',          960.00, 96.00,1056.00, 'USD', 'NET 15', 'Dev PO 2', NOW(), @seed_admin_id, @seed_admin_id, @seed_admin_id),
+    ('A8000000-0000-0000-0000-000000000003', 'PO-DEV-0003', 'A5000000-0000-0000-0000-000000000005', '93000000-0000-0000-0000-000000000001', '2026-03-03', '2026-03-07', 'PARTIALLY_RECEIVED', 700.00, 70.00, 770.00, 'USD', 'NET 30', 'Dev PO 3', NOW(), @seed_admin_id, @seed_admin_id, @seed_admin_id),
+    ('A8000000-0000-0000-0000-000000000004', 'PO-DEV-0004', 'A5000000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', '2026-03-04', '2026-03-08', 'COMPLETED',         1200.00,120.00,1320.00, 'USD', 'NET 30', 'Dev PO 4', NOW(), @seed_admin_id, @seed_admin_id, @seed_admin_id),
+    ('A8000000-0000-0000-0000-000000000005', 'PO-DEV-0005', 'A5000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '2026-03-05', '2026-03-09', 'CANCELLED',          300.00, 30.00, 330.00, 'USD', 'NET 15', 'Dev PO 5', NOW(), @seed_admin_id, @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO purchase_order_lines
+(
+    id, purchase_order_id, product_id, line_number, quantity_ordered, quantity_received,
+    unit_price, line_total, notes, created_by, updated_by
+)
+VALUES
+    ('A8100000-0000-0000-0000-000000000001', 'A8000000-0000-0000-0000-000000000001', '95000000-0000-0000-0000-000000000001', 1,  50.00,  0.00, 10.00,  500.00, 'PO line 1', @seed_admin_id, @seed_admin_id),
+    ('A8100000-0000-0000-0000-000000000002', 'A8000000-0000-0000-0000-000000000002', '95000000-0000-0000-0000-000000000002', 1,  80.00, 80.00, 12.00,  960.00, 'PO line 2', @seed_admin_id, @seed_admin_id),
+    ('A8100000-0000-0000-0000-000000000003', 'A8000000-0000-0000-0000-000000000003', '95000000-0000-0000-0000-000000000003', 1, 100.00, 40.00,  7.00,  700.00, 'PO line 3', @seed_admin_id, @seed_admin_id),
+    ('A8100000-0000-0000-0000-000000000004', 'A8000000-0000-0000-0000-000000000004', '95000000-0000-0000-0000-000000000004', 1,  60.00, 60.00, 20.00, 1200.00, 'PO line 4', @seed_admin_id, @seed_admin_id),
+    ('A8100000-0000-0000-0000-000000000005', 'A8000000-0000-0000-0000-000000000005', '95000000-0000-0000-0000-000000000005', 1,  10.00,  0.00, 30.00,  300.00, 'PO line 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO inbound_receipts
+(
+    id, receipt_number, purchase_order_id, warehouse_id, receipt_date, status,
+    confirmed_at, confirmed_by, delivery_note_number, notes, created_by, updated_by
+)
+VALUES
+    ('A8200000-0000-0000-0000-000000000001', 'IR-DEV-0001', 'A8000000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', '2026-03-05', 'DRAFT',     NULL, NULL,            'DN-0001', 'Inbound receipt 1', @seed_admin_id, @seed_admin_id),
+    ('A8200000-0000-0000-0000-000000000002', 'IR-DEV-0002', 'A8000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '2026-03-06', 'CONFIRMED', NOW(), @seed_admin_id, 'DN-0002', 'Inbound receipt 2', @seed_admin_id, @seed_admin_id),
+    ('A8200000-0000-0000-0000-000000000003', 'IR-DEV-0003', 'A8000000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', '2026-03-07', 'CONFIRMED', NOW(), @seed_admin_id, 'DN-0003', 'Inbound receipt 3', @seed_admin_id, @seed_admin_id),
+    ('A8200000-0000-0000-0000-000000000004', 'IR-DEV-0004', 'A8000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '2026-03-08', 'CONFIRMED', NOW(), @seed_admin_id, 'DN-0004', 'Inbound receipt 4', @seed_admin_id, @seed_admin_id),
+    ('A8200000-0000-0000-0000-000000000005', 'IR-DEV-0005', 'A8000000-0000-0000-0000-000000000005', '93000000-0000-0000-0000-000000000001', '2026-03-09', 'CANCELLED', NOW(), @seed_admin_id, 'DN-0005', 'Inbound receipt 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO inbound_receipt_lines
+(
+    id, inbound_receipt_id, purchase_order_line_id, product_id, batch_id, location_id,
+    line_number, quantity_received, quality_status, notes, created_by, updated_by
+)
+VALUES
+    ('A8300000-0000-0000-0000-000000000001', 'A8200000-0000-0000-0000-000000000001', 'A8100000-0000-0000-0000-000000000001', '95000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000001', 1, 10.00, 'PASS',       'Receipt line 1', @seed_admin_id, @seed_admin_id),
+    ('A8300000-0000-0000-0000-000000000002', 'A8200000-0000-0000-0000-000000000002', 'A8100000-0000-0000-0000-000000000002', '95000000-0000-0000-0000-000000000002', '96000000-0000-0000-0000-000000000002', '94000000-0000-0000-0000-000000000002', 1, 80.00, 'PASS',       'Receipt line 2', @seed_admin_id, @seed_admin_id),
+    ('A8300000-0000-0000-0000-000000000003', 'A8200000-0000-0000-0000-000000000003', 'A8100000-0000-0000-0000-000000000003', '95000000-0000-0000-0000-000000000003', '96000000-0000-0000-0000-000000000003', '94000000-0000-0000-0000-000000000003', 1, 40.00, 'QUARANTINE', 'Receipt line 3', @seed_admin_id, @seed_admin_id),
+    ('A8300000-0000-0000-0000-000000000004', 'A8200000-0000-0000-0000-000000000004', 'A8100000-0000-0000-0000-000000000004', '95000000-0000-0000-0000-000000000004', '96000000-0000-0000-0000-000000000004', '94000000-0000-0000-0000-000000000004', 1, 60.00, 'PASS',       'Receipt line 4', @seed_admin_id, @seed_admin_id),
+    ('A8300000-0000-0000-0000-000000000005', 'A8200000-0000-0000-0000-000000000005', 'A8100000-0000-0000-0000-000000000005', '95000000-0000-0000-0000-000000000005', '96000000-0000-0000-0000-000000000005', '94000000-0000-0000-0000-000000000005', 1,  5.00, 'PASS',       'Receipt line 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ================================
+-- Outbound Operations
+-- ================================
+INSERT INTO sales_orders
+(
+    id, so_number, customer_id, warehouse_id, order_date, requested_delivery_date, status,
+    sub_total, tax_amount, total_amount, currency, notes, confirmed_at, confirmed_by,
+    created_by, updated_by
+)
+VALUES
+    ('A8400000-0000-0000-0000-000000000001', 'SO-DEV-0001', 'A5000000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', '2026-03-10', '2026-03-12', 'DRAFT',             420.00, 42.00, 462.00, 'USD', 'Sales order 1', NULL, NULL, @seed_admin_id, @seed_admin_id),
+    ('A8400000-0000-0000-0000-000000000002', 'SO-DEV-0002', 'A5000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '2026-03-10', '2026-03-12', 'CONFIRMED',         300.00, 30.00, 330.00, 'USD', 'Sales order 2', NOW(), @seed_admin_id, @seed_admin_id, @seed_admin_id),
+    ('A8400000-0000-0000-0000-000000000003', 'SO-DEV-0003', 'A5000000-0000-0000-0000-000000000005', '93000000-0000-0000-0000-000000000001', '2026-03-11', '2026-03-13', 'PARTIALLY_SHIPPED', 200.00, 20.00, 220.00, 'USD', 'Sales order 3', NOW(), @seed_admin_id, @seed_admin_id, @seed_admin_id),
+    ('A8400000-0000-0000-0000-000000000004', 'SO-DEV-0004', 'A5000000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', '2026-03-11', '2026-03-14', 'COMPLETED',         560.00, 56.00, 616.00, 'USD', 'Sales order 4', NOW(), @seed_admin_id, @seed_admin_id, @seed_admin_id),
+    ('A8400000-0000-0000-0000-000000000005', 'SO-DEV-0005', 'A5000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '2026-03-12', '2026-03-15', 'CANCELLED',         150.00, 15.00, 165.00, 'USD', 'Sales order 5', NOW(), @seed_admin_id, @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO sales_order_lines
+(
+    id, sales_order_id, product_id, line_number, quantity_ordered, quantity_shipped,
+    unit_price, line_total, notes, created_by, updated_by
+)
+VALUES
+    ('A8500000-0000-0000-0000-000000000001', 'A8400000-0000-0000-0000-000000000001', '95000000-0000-0000-0000-000000000001', 1, 30.00,  0.00, 14.00, 420.00, 'SO line 1', @seed_admin_id, @seed_admin_id),
+    ('A8500000-0000-0000-0000-000000000002', 'A8400000-0000-0000-0000-000000000002', '95000000-0000-0000-0000-000000000002', 1, 20.00, 20.00, 15.00, 300.00, 'SO line 2', @seed_admin_id, @seed_admin_id),
+    ('A8500000-0000-0000-0000-000000000003', 'A8400000-0000-0000-0000-000000000003', '95000000-0000-0000-0000-000000000003', 1, 25.00, 10.00,  8.00, 200.00, 'SO line 3', @seed_admin_id, @seed_admin_id),
+    ('A8500000-0000-0000-0000-000000000004', 'A8400000-0000-0000-0000-000000000004', '95000000-0000-0000-0000-000000000004', 1, 20.00, 20.00, 28.00, 560.00, 'SO line 4', @seed_admin_id, @seed_admin_id),
+    ('A8500000-0000-0000-0000-000000000005', 'A8400000-0000-0000-0000-000000000005', '95000000-0000-0000-0000-000000000005', 1,  5.00,  0.00, 30.00, 150.00, 'SO line 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO outbound_shipments
+(
+    id, shipment_number, sales_order_id, warehouse_id, shipment_date, status,
+    tracking_number, carrier, shipped_at, confirmed_by, notes, created_by, updated_by
+)
+VALUES
+    ('A8600000-0000-0000-0000-000000000001', 'OS-DEV-0001', 'A8400000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', '2026-03-12', 'DRAFT',     NULL,       NULL,        NULL, NULL,          'Shipment 1', @seed_admin_id, @seed_admin_id),
+    ('A8600000-0000-0000-0000-000000000002', 'OS-DEV-0002', 'A8400000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '2026-03-12', 'SHIPPED',   'TRK-0002', 'DHL',       NOW(), @seed_admin_id, 'Shipment 2', @seed_admin_id, @seed_admin_id),
+    ('A8600000-0000-0000-0000-000000000003', 'OS-DEV-0003', 'A8400000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', '2026-03-13', 'PACKED',    'TRK-0003', 'FedEx',     NULL,  @seed_admin_id, 'Shipment 3', @seed_admin_id, @seed_admin_id),
+    ('A8600000-0000-0000-0000-000000000004', 'OS-DEV-0004', 'A8400000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '2026-03-13', 'SHIPPED',   'TRK-0004', 'VNPost',    NOW(), @seed_admin_id, 'Shipment 4', @seed_admin_id, @seed_admin_id),
+    ('A8600000-0000-0000-0000-000000000005', 'OS-DEV-0005', 'A8400000-0000-0000-0000-000000000005', '93000000-0000-0000-0000-000000000001', '2026-03-14', 'CANCELLED', 'TRK-0005', 'JNT',       NULL,  @seed_admin_id, 'Shipment 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+INSERT INTO outbound_shipment_lines
+(
+    id, outbound_shipment_id, sales_order_line_id, product_id, batch_id, location_id,
+    line_number, quantity_shipped, picked_at, picked_by, notes, created_by, updated_by
+)
+VALUES
+    ('A8700000-0000-0000-0000-000000000001', 'A8600000-0000-0000-0000-000000000001', 'A8500000-0000-0000-0000-000000000001', '95000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000001', 1,  0.00, NULL, NULL,          'Shipment line 1', @seed_admin_id, @seed_admin_id),
+    ('A8700000-0000-0000-0000-000000000002', 'A8600000-0000-0000-0000-000000000002', 'A8500000-0000-0000-0000-000000000002', '95000000-0000-0000-0000-000000000002', '96000000-0000-0000-0000-000000000002', '94000000-0000-0000-0000-000000000002', 1, 20.00, NOW(), @seed_admin_id, 'Shipment line 2', @seed_admin_id, @seed_admin_id),
+    ('A8700000-0000-0000-0000-000000000003', 'A8600000-0000-0000-0000-000000000003', 'A8500000-0000-0000-0000-000000000003', '95000000-0000-0000-0000-000000000003', '96000000-0000-0000-0000-000000000003', '94000000-0000-0000-0000-000000000003', 1, 10.00, NOW(), @seed_admin_id, 'Shipment line 3', @seed_admin_id, @seed_admin_id),
+    ('A8700000-0000-0000-0000-000000000004', 'A8600000-0000-0000-0000-000000000004', 'A8500000-0000-0000-0000-000000000004', '95000000-0000-0000-0000-000000000004', '96000000-0000-0000-0000-000000000004', '94000000-0000-0000-0000-000000000004', 1, 20.00, NOW(), @seed_admin_id, 'Shipment line 4', @seed_admin_id, @seed_admin_id),
+    ('A8700000-0000-0000-0000-000000000005', 'A8600000-0000-0000-0000-000000000005', 'A8500000-0000-0000-0000-000000000005', '95000000-0000-0000-0000-000000000005', '96000000-0000-0000-0000-000000000005', '94000000-0000-0000-0000-000000000005', 1,  0.00, NULL, NULL,          'Shipment line 5', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ================================
+-- Additional stock movements for inbound/outbound flows
+-- ================================
+INSERT INTO stock_movements
+(
+    id, movement_type, product_id, warehouse_id, location_id, batch_id,
+    quantity_change, quantity_before, quantity_after, movement_date,
+    reference_type, reference_id, reference_number, notes, created_by, updated_by
+)
+VALUES
+    ('A8800000-0000-0000-0000-000000000001', 'INBOUND',             '95000000-0000-0000-0000-000000000001', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000001', '96000000-0000-0000-0000-000000000001',  10.00, 100.00, 110.00, NOW(), 'INBOUND_RECEIPT',  'A8200000-0000-0000-0000-000000000001', 'IR-DEV-0001', 'Inbound from receipt 1',   @seed_admin_id, @seed_admin_id),
+    ('A8800000-0000-0000-0000-000000000002', 'INBOUND',             '95000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000002', '96000000-0000-0000-0000-000000000002',  80.00,  15.00,  95.00, NOW(), 'INBOUND_RECEIPT',  'A8200000-0000-0000-0000-000000000002', 'IR-DEV-0002', 'Inbound from receipt 2',   @seed_admin_id, @seed_admin_id),
+    ('A8800000-0000-0000-0000-000000000003', 'OUTBOUND',            '95000000-0000-0000-0000-000000000002', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000002', '96000000-0000-0000-0000-000000000002', -20.00,  95.00,  75.00, NOW(), 'OUTBOUND_SHIPMENT','A8600000-0000-0000-0000-000000000002', 'OS-DEV-0002', 'Outbound for shipment 2', @seed_admin_id, @seed_admin_id),
+    ('A8800000-0000-0000-0000-000000000004', 'OUTBOUND',            '95000000-0000-0000-0000-000000000003', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000003', '96000000-0000-0000-0000-000000000003', -10.00,  60.00,  50.00, NOW(), 'OUTBOUND_SHIPMENT','A8600000-0000-0000-0000-000000000003', 'OS-DEV-0003', 'Outbound for shipment 3', @seed_admin_id, @seed_admin_id),
+    ('A8800000-0000-0000-0000-000000000005', 'OUTBOUND',            '95000000-0000-0000-0000-000000000004', '93000000-0000-0000-0000-000000000001', '94000000-0000-0000-0000-000000000004', '96000000-0000-0000-0000-000000000004', -20.00, 170.00, 150.00, NOW(), 'OUTBOUND_SHIPMENT','A8600000-0000-0000-0000-000000000004', 'OS-DEV-0004', 'Outbound for shipment 4', @seed_admin_id, @seed_admin_id)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ================================
+-- Email logs
+-- ================================
+INSERT INTO email_logs
+(
+    id, recipient, cc, bcc, subject, content, email_type, status,
+    retry_count, max_retry, error_message, sent_at, has_attachment, attachment_path,
+    priority, scheduled_at, triggered_by, created_by, updated_by
+)
+VALUES
+    ('A8900000-0000-0000-0000-000000000001', 'cust.dev01@whs.local', NULL, NULL, 'Welcome to WMS',      'Welcome email content',         'WELCOME',         'SENT',    0, 3, NULL, NOW(), TRUE,  '/tmp/welcome-1.pdf', 5, NOW(), @seed_admin_id, 'system', 'system'),
+    ('A8900000-0000-0000-0000-000000000002', 'cust.dev02@whs.local', NULL, NULL, 'Password Reset',      'Password reset email content',  'PASSWORD_RESET',  'FAILED',  2, 3, 'SMTP timeout', NULL, FALSE, NULL,               4, NOW(), @seed_admin_id, 'system', 'system'),
+    ('A8900000-0000-0000-0000-000000000003', 'emp.dev01@whs.local',  NULL, NULL, 'Inventory Alert',     'Inventory threshold alert',     'ALERT',           'PENDING', 0, 3, NULL, NULL, FALSE, NULL,               3, NOW(), @seed_admin_id, 'system', 'system'),
+    ('A8900000-0000-0000-0000-000000000004', 'emp.dev02@whs.local',  NULL, NULL, 'Shipment Notification','Shipment processed notification','NOTIFICATION',    'SENT',    0, 3, NULL, NOW(), FALSE, NULL,               6, NOW(), @seed_admin_id, 'system', 'system'),
+    ('A8900000-0000-0000-0000-000000000005', 'cust.dev03@whs.local', NULL, NULL, 'Order Confirmation',  'Order confirmation content',    'ORDER_CONFIRM',   'RETRY',   1, 3, 'Temporary SMTP error', NULL, FALSE, NULL,      5, NOW(), @seed_admin_id, 'system', 'system')
+ON DUPLICATE KEY UPDATE id = id;
+
+-- ============================================================================
+-- End of Migration
+-- ============================================================================

--- a/src/test/java/org/demo/whs/repository/InventoryOptimisticLockIntegrationTest.java
+++ b/src/test/java/org/demo/whs/repository/InventoryOptimisticLockIntegrationTest.java
@@ -1,0 +1,67 @@
+package org.demo.whs.repository;
+
+import org.demo.whs.entity.Inventory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("Inventory Optimistic Lock Integration Tests")
+class InventoryOptimisticLockIntegrationTest {
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void should_PreventStaleVersionUpdate_When_ConcurrentInventoryUpdatesOccur() {
+        TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
+
+        String inventoryId = txTemplate.execute(status -> {
+            Inventory inventory = Inventory.builder()
+                    .productId("prod-1")
+                    .warehouseId("wh-1")
+                    .locationId("loc-1")
+                    .batchId("batch-1")
+                    .onHandQuantity(new BigDecimal("100.00"))
+                    .reservedQuantity(new BigDecimal("10.00"))
+                    .version(0)
+                    .build();
+            return inventoryRepository.saveAndFlush(inventory).getId();
+        });
+
+        Integer staleVersion = txTemplate.execute(status -> inventoryRepository.findById(inventoryId)
+                .map(Inventory::getVersion)
+                .orElseThrow());
+
+        txTemplate.executeWithoutResult(status -> {
+            Inventory current = inventoryRepository.findById(inventoryId).orElseThrow();
+            current.setOnHandQuantity(new BigDecimal("80.00"));
+            inventoryRepository.saveAndFlush(current);
+        });
+
+        Integer updatedRows = txTemplate.execute(status -> jdbcTemplate.update(
+                "UPDATE inventory SET on_hand_quantity = ?, version = version + 1 WHERE id = ? AND version = ?",
+                new BigDecimal("70.00"),
+                inventoryId,
+                staleVersion
+        ));
+
+        assertThat(updatedRows).isZero();
+    }
+}

--- a/src/test/java/org/demo/whs/repository/StockAdjustmentsConstraintIntegrationTest.java
+++ b/src/test/java/org/demo/whs/repository/StockAdjustmentsConstraintIntegrationTest.java
@@ -1,0 +1,83 @@
+package org.demo.whs.repository;
+
+import org.demo.whs.entity.StockAdjustments;
+import org.demo.whs.entity.enums.ReasonType;
+import org.demo.whs.entity.enums.StockAdjustmentsStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("StockAdjustments Constraint Integration Tests")
+class StockAdjustmentsConstraintIntegrationTest {
+
+    @Autowired
+    private StockAdjustmentsRepository stockAdjustmentsRepository;
+
+    @Test
+    void should_RejectAdjustment_When_AdjustmentQuantityIsZero() {
+        StockAdjustments adjustment = baseAdjustment();
+        adjustment.setQuantityBefore(new BigDecimal("100.00"));
+        adjustment.setQuantityAfter(new BigDecimal("100.00"));
+        adjustment.setAdjustmentQuantity(BigDecimal.ZERO);
+
+        assertThatThrownBy(() -> stockAdjustmentsRepository.saveAndFlush(adjustment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void should_RejectAdjustment_When_ApprovedWithoutApprovalMetadata() {
+        StockAdjustments adjustment = baseAdjustment();
+        adjustment.setStatus(StockAdjustmentsStatus.APPROVED);
+        adjustment.setQuantityBefore(new BigDecimal("100.00"));
+        adjustment.setQuantityAfter(new BigDecimal("120.00"));
+        adjustment.setAdjustmentQuantity(new BigDecimal("20.00"));
+
+        assertThatThrownBy(() -> stockAdjustmentsRepository.saveAndFlush(adjustment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void should_SaveAdjustment_When_ApprovedWithApprovalMetadata() {
+        StockAdjustments adjustment = baseAdjustment();
+        adjustment.setStatus(StockAdjustmentsStatus.APPROVED);
+        adjustment.setQuantityBefore(new BigDecimal("100.00"));
+        adjustment.setQuantityAfter(new BigDecimal("130.00"));
+        adjustment.setAdjustmentQuantity(new BigDecimal("30.00"));
+        adjustment.setApprovedBy("acc-1");
+        adjustment.setApprovedAt(LocalDateTime.now());
+
+        StockAdjustments saved = stockAdjustmentsRepository.saveAndFlush(adjustment);
+
+        assertThat(saved.getId()).isNotBlank();
+    }
+
+    private StockAdjustments baseAdjustment() {
+        return StockAdjustments.builder()
+                .adjustmentNumber("ADJ-TEST-" + UUID.randomUUID())
+                .inventoryId("inv-1")
+                .productId("prod-1")
+                .warehouseId("wh-1")
+                .locationId("loc-1")
+                .batchId("batch-1")
+                .quantityBefore(new BigDecimal("100.00"))
+                .quantityAfter(new BigDecimal("120.00"))
+                .adjustmentQuantity(new BigDecimal("20.00"))
+                .reason(ReasonType.COUNT_ERROR)
+                .status(StockAdjustmentsStatus.PENDING_APPROVAL)
+                .notes("test")
+                .requiresApproval(true)
+                .build();
+    }
+}

--- a/src/test/java/org/demo/whs/service/impl/StockAdjustmentsServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/StockAdjustmentsServiceImplTest.java
@@ -1,0 +1,275 @@
+package org.demo.whs.service.impl;
+
+import org.demo.whs.entity.Account;
+import org.demo.whs.entity.Inventory;
+import org.demo.whs.entity.StockAdjustments;
+import org.demo.whs.entity.StockMovements;
+import org.demo.whs.entity.dto.request.StockAdjustments.ApproveStockAdjustmentRequest;
+import org.demo.whs.entity.dto.request.StockAdjustments.RejectStockAdjustmentRequest;
+import org.demo.whs.entity.dto.request.StockAdjustments.StockAdjustmentsRequest;
+import org.demo.whs.entity.dto.response.StockAdjustments.StockAdjustmentsResponse;
+import org.demo.whs.entity.enums.AccountStatus;
+import org.demo.whs.entity.enums.ReasonType;
+import org.demo.whs.entity.enums.StockAdjustmentsStatus;
+import org.demo.whs.entity.enums.StockMovementsType;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.mapper.StockAdjustmentsMapper;
+import org.demo.whs.mapper.StockMovementsMapper;
+import org.demo.whs.repository.AccountRepository;
+import org.demo.whs.repository.InventoryRepository;
+import org.demo.whs.repository.StockAdjustmentsRepository;
+import org.demo.whs.repository.StockMovementsRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StockAdjustmentsServiceImpl Unit Tests")
+class StockAdjustmentsServiceImplTest {
+
+    @Mock
+    private StockAdjustmentsRepository stockAdjustmentsRepository;
+
+    @Mock
+    private InventoryRepository inventoryRepository;
+
+    @Mock
+    private StockMovementsRepository stockMovementsRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    private StockAdjustmentsServiceImpl stockAdjustmentsService;
+
+    @BeforeEach
+    void setUp() {
+        stockAdjustmentsService = new StockAdjustmentsServiceImpl(
+                stockAdjustmentsRepository,
+                inventoryRepository,
+                stockMovementsRepository,
+                accountRepository,
+                new StockAdjustmentsMapper(),
+                new StockMovementsMapper()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("tester", "password", List.of())
+        );
+
+        Account account = Account.builder()
+                .username("tester")
+                .password("secret")
+                .status(AccountStatus.ACTIVE)
+                .build();
+        account.setId("acc-1");
+
+        lenient().when(accountRepository.findByUsername("tester")).thenReturn(Optional.of(account));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void should_CreatePendingAdjustment_When_RequestRequiresApproval() {
+        Inventory inventory = buildInventory("inv-1", "100.00", "10.00");
+        StockAdjustmentsRequest request = buildAdjustmentRequest("inv-1", "120.00", true);
+
+        when(inventoryRepository.findByIdForUpdate("inv-1")).thenReturn(Optional.of(inventory));
+        when(stockAdjustmentsRepository.existsByAdjustmentNumber(anyString())).thenReturn(false);
+        when(stockAdjustmentsRepository.save(any(StockAdjustments.class))).thenAnswer(invocation -> {
+            StockAdjustments adjustment = invocation.getArgument(0);
+            adjustment.setId("adj-1");
+            return adjustment;
+        });
+
+        StockAdjustmentsResponse response = stockAdjustmentsService.createAdjustment(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(StockAdjustmentsStatus.PENDING_APPROVAL);
+        assertThat(response.getAdjustmentQuantity()).isEqualByComparingTo("20.00");
+
+        verify(inventoryRepository, never()).save(any(Inventory.class));
+        verify(stockMovementsRepository, never()).save(any(StockMovements.class));
+    }
+
+    @Test
+    void should_CreateAutoApprovedAdjustmentAndMovement_When_RequestDoesNotRequireApproval() {
+        Inventory inventory = buildInventory("inv-1", "100.00", "10.00");
+        StockAdjustmentsRequest request = buildAdjustmentRequest("inv-1", "80.00", false);
+
+        when(inventoryRepository.findByIdForUpdate("inv-1")).thenReturn(Optional.of(inventory));
+        when(stockAdjustmentsRepository.existsByAdjustmentNumber(anyString())).thenReturn(false);
+        when(stockAdjustmentsRepository.save(any(StockAdjustments.class))).thenAnswer(invocation -> {
+            StockAdjustments adjustment = invocation.getArgument(0);
+            adjustment.setId("adj-2");
+            return adjustment;
+        });
+
+        StockAdjustmentsResponse response = stockAdjustmentsService.createAdjustment(request);
+
+        assertThat(response.getStatus()).isEqualTo(StockAdjustmentsStatus.APPROVED);
+
+        ArgumentCaptor<Inventory> inventoryCaptor = ArgumentCaptor.forClass(Inventory.class);
+        verify(inventoryRepository).save(inventoryCaptor.capture());
+        assertThat(inventoryCaptor.getValue().getOnHandQuantity()).isEqualByComparingTo("80.00");
+
+        ArgumentCaptor<StockMovements> movementCaptor = ArgumentCaptor.forClass(StockMovements.class);
+        verify(stockMovementsRepository).save(movementCaptor.capture());
+        assertThat(movementCaptor.getValue().getMovementType()).isEqualTo(StockMovementsType.ADJUSTMENT_DECREASE);
+        assertThat(movementCaptor.getValue().getQuantityChange()).isEqualByComparingTo("-20.00");
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_AdjustmentQuantityIsZero() {
+        Inventory inventory = buildInventory("inv-1", "100.00", "10.00");
+        StockAdjustmentsRequest request = buildAdjustmentRequest("inv-1", "100.00", true);
+
+        when(inventoryRepository.findByIdForUpdate("inv-1")).thenReturn(Optional.of(inventory));
+
+        assertThatThrownBy(() -> stockAdjustmentsService.createAdjustment(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "STA_001");
+
+        verify(stockAdjustmentsRepository, never()).save(any(StockAdjustments.class));
+    }
+
+    @Test
+    void should_ApproveAdjustmentAndCreateMovement_When_StatusIsPendingApproval() {
+        Inventory inventory = buildInventory("inv-1", "100.00", "10.00");
+
+        StockAdjustments adjustment = StockAdjustments.builder()
+                .inventoryId("inv-1")
+                .productId("prod-1")
+                .warehouseId("wh-1")
+                .locationId("loc-1")
+                .batchId("batch-1")
+                .quantityBefore(new BigDecimal("100.00"))
+                .quantityAfter(new BigDecimal("130.00"))
+                .adjustmentQuantity(new BigDecimal("30.00"))
+                .reason(ReasonType.COUNT_ERROR)
+                .status(StockAdjustmentsStatus.PENDING_APPROVAL)
+                .requiresApproval(true)
+                .build();
+        adjustment.setId("adj-3");
+        adjustment.setAdjustmentNumber("ADJ-001");
+
+        ApproveStockAdjustmentRequest approveRequest = new ApproveStockAdjustmentRequest();
+        setField(approveRequest, "approvalNote", "Count verified");
+
+        when(stockAdjustmentsRepository.findByIdForUpdate("adj-3")).thenReturn(Optional.of(adjustment));
+        when(inventoryRepository.findByIdForUpdate("inv-1")).thenReturn(Optional.of(inventory));
+        when(stockAdjustmentsRepository.save(any(StockAdjustments.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        StockAdjustmentsResponse response = stockAdjustmentsService.approve("adj-3", approveRequest);
+
+        assertThat(response.getStatus()).isEqualTo(StockAdjustmentsStatus.APPROVED);
+        assertThat(inventory.getOnHandQuantity()).isEqualByComparingTo("130.00");
+
+        ArgumentCaptor<StockMovements> movementCaptor = ArgumentCaptor.forClass(StockMovements.class);
+        verify(stockMovementsRepository).save(movementCaptor.capture());
+        assertThat(movementCaptor.getValue().getMovementType()).isEqualTo(StockMovementsType.ADJUSTMENT_INCREASE);
+        assertThat(movementCaptor.getValue().getQuantityChange()).isEqualByComparingTo("30.00");
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_ApproveAdjustmentInInvalidStatus() {
+        StockAdjustments adjustment = StockAdjustments.builder()
+                .inventoryId("inv-1")
+                .status(StockAdjustmentsStatus.APPROVED)
+                .build();
+        adjustment.setId("adj-4");
+
+        when(stockAdjustmentsRepository.findByIdForUpdate("adj-4")).thenReturn(Optional.of(adjustment));
+
+        assertThatThrownBy(() -> stockAdjustmentsService.approve("adj-4", new ApproveStockAdjustmentRequest()))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "STA_002");
+
+        verify(inventoryRepository, never()).findByIdForUpdate(anyString());
+    }
+
+    @Test
+    void should_RejectAdjustmentWithoutInventorySideEffects_When_StatusIsPendingApproval() {
+        StockAdjustments adjustment = StockAdjustments.builder()
+                .inventoryId("inv-1")
+                .status(StockAdjustmentsStatus.PENDING_APPROVAL)
+                .quantityBefore(new BigDecimal("100.00"))
+                .quantityAfter(new BigDecimal("90.00"))
+                .adjustmentQuantity(new BigDecimal("-10.00"))
+                .reason(ReasonType.DAMAGE)
+                .requiresApproval(true)
+                .build();
+        adjustment.setId("adj-5");
+
+        RejectStockAdjustmentRequest rejectRequest = new RejectStockAdjustmentRequest();
+        setField(rejectRequest, "rejectionReason", "Evidence insufficient");
+
+        when(stockAdjustmentsRepository.findByIdForUpdate("adj-5")).thenReturn(Optional.of(adjustment));
+        when(stockAdjustmentsRepository.save(any(StockAdjustments.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        StockAdjustmentsResponse response = stockAdjustmentsService.reject("adj-5", rejectRequest);
+
+        assertThat(response.getStatus()).isEqualTo(StockAdjustmentsStatus.REJECTED);
+        assertThat(response.getRejectionReason()).isEqualTo("Evidence insufficient");
+
+        verify(inventoryRepository, never()).save(any(Inventory.class));
+        verify(stockMovementsRepository, never()).save(any(StockMovements.class));
+    }
+
+    private Inventory buildInventory(String id, String onHand, String reserved) {
+        Inventory inventory = Inventory.builder()
+                .productId("prod-1")
+                .warehouseId("wh-1")
+                .locationId("loc-1")
+                .batchId("batch-1")
+                .onHandQuantity(new BigDecimal(onHand))
+                .reservedQuantity(new BigDecimal(reserved))
+                .version(0)
+                .build();
+        inventory.setId(id);
+        return inventory;
+    }
+
+    private StockAdjustmentsRequest buildAdjustmentRequest(String inventoryId, String quantityAfter, boolean requiresApproval) {
+        StockAdjustmentsRequest request = new StockAdjustmentsRequest();
+        setField(request, "inventoryId", inventoryId);
+        setField(request, "quantityAfter", new BigDecimal(quantityAfter));
+        setField(request, "reason", ReasonType.COUNT_ERROR);
+        setField(request, "notes", "Cycle count");
+        setField(request, "requiresApproval", requiresApproval);
+        return request;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Failed to set field " + fieldName, ex);
+        }
+    }
+}

--- a/src/test/java/org/demo/whs/service/impl/StockTransfersServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/StockTransfersServiceImplTest.java
@@ -1,0 +1,318 @@
+package org.demo.whs.service.impl;
+
+import org.demo.whs.entity.Account;
+import org.demo.whs.entity.Batch;
+import org.demo.whs.entity.Inventory;
+import org.demo.whs.entity.Locations;
+import org.demo.whs.entity.StockMovements;
+import org.demo.whs.entity.StockTransfers;
+import org.demo.whs.entity.dto.request.StockTransfers.StockTransfersRequest;
+import org.demo.whs.entity.dto.response.StockTransfers.StockTransfersResponse;
+import org.demo.whs.entity.enums.AccountStatus;
+import org.demo.whs.entity.enums.StockMovementsType;
+import org.demo.whs.entity.enums.StockTransfersReason;
+import org.demo.whs.entity.enums.StockTransfersStatus;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.mapper.StockMovementsMapper;
+import org.demo.whs.mapper.StockTransfersMapper;
+import org.demo.whs.repository.AccountRepository;
+import org.demo.whs.repository.BatchRepository;
+import org.demo.whs.repository.InventoryRepository;
+import org.demo.whs.repository.LocationRepository;
+import org.demo.whs.repository.ProductRepository;
+import org.demo.whs.repository.StockMovementsRepository;
+import org.demo.whs.repository.StockTransfersRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StockTransfersServiceImpl Unit Tests")
+class StockTransfersServiceImplTest {
+
+    @Mock
+    private StockTransfersRepository stockTransfersRepository;
+
+    @Mock
+    private InventoryRepository inventoryRepository;
+
+    @Mock
+    private StockMovementsRepository stockMovementsRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @Mock
+    private BatchRepository batchRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    private StockTransfersServiceImpl stockTransfersService;
+
+    @BeforeEach
+    void setUp() {
+        stockTransfersService = new StockTransfersServiceImpl(
+                stockTransfersRepository,
+                inventoryRepository,
+                stockMovementsRepository,
+                productRepository,
+                locationRepository,
+                batchRepository,
+                accountRepository,
+                new StockTransfersMapper(),
+                new StockMovementsMapper()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("tester", "password", List.of())
+        );
+
+        Account account = Account.builder()
+                .username("tester")
+                .password("secret")
+                .status(AccountStatus.ACTIVE)
+                .build();
+        account.setId("acc-1");
+        lenient().when(accountRepository.findByUsername("tester")).thenReturn(Optional.of(account));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void should_CreateDraftTransfer_When_RequestValid() {
+        StockTransfersRequest request = buildTransferRequest("10.00");
+
+        Locations from = new Locations();
+        from.setId("loc-1");
+        from.setWarehouseId("wh-1");
+
+        Locations to = new Locations();
+        to.setId("loc-2");
+        to.setWarehouseId("wh-1");
+
+        when(productRepository.existsById("prod-1")).thenReturn(true);
+        when(locationRepository.findById("loc-1")).thenReturn(Optional.of(from));
+        when(locationRepository.findById("loc-2")).thenReturn(Optional.of(to));
+        when(stockTransfersRepository.existsByTransferNumber(anyString())).thenReturn(false);
+        when(stockTransfersRepository.save(any(StockTransfers.class))).thenAnswer(invocation -> {
+            StockTransfers transfer = invocation.getArgument(0);
+            transfer.setId("trf-1");
+            return transfer;
+        });
+
+        StockTransfersResponse response = stockTransfersService.createTransfer(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(StockTransfersStatus.DRAFT);
+        assertThat(response.getQuantity()).isEqualByComparingTo("10.00");
+    }
+
+    @Test
+    void should_CompleteTransferAndCreateTwoMovements_When_TransferDraftAndStockAvailable() {
+        StockTransfers transfer = StockTransfers.builder()
+                .transferNumber("TRF-001")
+                .productId("prod-1")
+                .warehouseId("wh-1")
+                .fromLocationId("loc-1")
+                .toLocationId("loc-2")
+                .batchId("batch-1")
+                .quantity(new BigDecimal("20.00"))
+                .reason(StockTransfersReason.REORG)
+                .status(StockTransfersStatus.DRAFT)
+                .build();
+        transfer.setId("trf-2");
+
+        Inventory sourceInventory = Inventory.builder()
+                .productId("prod-1")
+                .warehouseId("wh-1")
+                .locationId("loc-1")
+                .batchId("batch-1")
+                .onHandQuantity(new BigDecimal("100.00"))
+                .reservedQuantity(new BigDecimal("10.00"))
+                .version(0)
+                .build();
+        sourceInventory.setId("inv-src");
+
+        Inventory destinationInventory = Inventory.builder()
+                .productId("prod-1")
+                .warehouseId("wh-1")
+                .locationId("loc-2")
+                .batchId("batch-1")
+                .onHandQuantity(new BigDecimal("5.00"))
+                .reservedQuantity(BigDecimal.ZERO)
+                .version(0)
+                .build();
+        destinationInventory.setId("inv-dst");
+
+        when(stockTransfersRepository.findByIdForUpdate("trf-2")).thenReturn(Optional.of(transfer));
+        when(inventoryRepository.findByDimensionForUpdate("prod-1", "wh-1", "loc-1", "batch-1"))
+                .thenReturn(Optional.of(sourceInventory));
+        when(inventoryRepository.findByDimensionForUpdate("prod-1", "wh-1", "loc-2", "batch-1"))
+                .thenReturn(Optional.of(destinationInventory));
+        when(stockTransfersRepository.save(any(StockTransfers.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        StockTransfersResponse response = stockTransfersService.complete("trf-2");
+
+        assertThat(response.getStatus()).isEqualTo(StockTransfersStatus.COMPLETED);
+        assertThat(sourceInventory.getOnHandQuantity()).isEqualByComparingTo("80.00");
+        assertThat(destinationInventory.getOnHandQuantity()).isEqualByComparingTo("25.00");
+
+        ArgumentCaptor<StockMovements> movementCaptor = ArgumentCaptor.forClass(StockMovements.class);
+        verify(stockMovementsRepository, times(2)).save(movementCaptor.capture());
+
+        assertThat(movementCaptor.getAllValues())
+                .extracting(StockMovements::getMovementType)
+                .containsExactlyInAnyOrder(StockMovementsType.TRANSFER_OUT, StockMovementsType.TRANSFER_IN);
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_CompleteTransferWithInsufficientAvailableStock() {
+        StockTransfers transfer = StockTransfers.builder()
+                .productId("prod-1")
+                .warehouseId("wh-1")
+                .fromLocationId("loc-1")
+                .toLocationId("loc-2")
+                .batchId("batch-1")
+                .quantity(new BigDecimal("10.00"))
+                .status(StockTransfersStatus.DRAFT)
+                .build();
+        transfer.setId("trf-3");
+
+        Inventory sourceInventory = Inventory.builder()
+                .productId("prod-1")
+                .warehouseId("wh-1")
+                .locationId("loc-1")
+                .batchId("batch-1")
+                .onHandQuantity(new BigDecimal("15.00"))
+                .reservedQuantity(new BigDecimal("10.00"))
+                .version(0)
+                .build();
+
+        when(stockTransfersRepository.findByIdForUpdate("trf-3")).thenReturn(Optional.of(transfer));
+        when(inventoryRepository.findByDimensionForUpdate("prod-1", "wh-1", "loc-1", "batch-1"))
+                .thenReturn(Optional.of(sourceInventory));
+        when(inventoryRepository.findByDimensionForUpdate("prod-1", "wh-1", "loc-2", "batch-1"))
+                .thenReturn(Optional.of(Inventory.builder()
+                        .productId("prod-1")
+                        .warehouseId("wh-1")
+                        .locationId("loc-2")
+                        .batchId("batch-1")
+                        .onHandQuantity(BigDecimal.ZERO)
+                        .reservedQuantity(BigDecimal.ZERO)
+                        .version(0)
+                        .build()));
+
+        assertThatThrownBy(() -> stockTransfersService.complete("trf-3"))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "INV_004");
+
+        verify(stockMovementsRepository, never()).save(any(StockMovements.class));
+    }
+
+    @Test
+    void should_CancelDraftTransfer_When_StatusIsDraft() {
+        StockTransfers transfer = StockTransfers.builder()
+                .status(StockTransfersStatus.DRAFT)
+                .build();
+        transfer.setId("trf-4");
+
+        when(stockTransfersRepository.findByIdForUpdate("trf-4")).thenReturn(Optional.of(transfer));
+        when(stockTransfersRepository.save(any(StockTransfers.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        StockTransfersResponse response = stockTransfersService.cancel("trf-4");
+
+        assertThat(response.getStatus()).isEqualTo(StockTransfersStatus.CANCELLED);
+        verify(stockMovementsRepository, never()).save(any(StockMovements.class));
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_CompleteTransferInInvalidStatus() {
+        StockTransfers transfer = StockTransfers.builder()
+                .status(StockTransfersStatus.COMPLETED)
+                .build();
+        transfer.setId("trf-5");
+
+        when(stockTransfersRepository.findByIdForUpdate("trf-5")).thenReturn(Optional.of(transfer));
+
+        assertThatThrownBy(() -> stockTransfersService.complete("trf-5"))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "STF_002");
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_BatchDoesNotBelongToProductOnCreate() {
+        StockTransfersRequest request = buildTransferRequest("5.00");
+        setField(request, "batchId", "batch-1");
+
+        Locations from = new Locations();
+        from.setWarehouseId("wh-1");
+
+        Locations to = new Locations();
+        to.setWarehouseId("wh-1");
+
+        Batch batch = Batch.builder()
+                .productId("another-product")
+                .build();
+        batch.setId("batch-1");
+
+        when(productRepository.existsById("prod-1")).thenReturn(true);
+        when(locationRepository.findById("loc-1")).thenReturn(Optional.of(from));
+        when(locationRepository.findById("loc-2")).thenReturn(Optional.of(to));
+        when(batchRepository.findById("batch-1")).thenReturn(Optional.of(batch));
+
+        assertThatThrownBy(() -> stockTransfersService.createTransfer(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "STF_002");
+    }
+
+    private StockTransfersRequest buildTransferRequest(String quantity) {
+        StockTransfersRequest request = new StockTransfersRequest();
+        setField(request, "productId", "prod-1");
+        setField(request, "warehouseId", "wh-1");
+        setField(request, "fromLocationId", "loc-1");
+        setField(request, "toLocationId", "loc-2");
+        setField(request, "quantity", new BigDecimal(quantity));
+        setField(request, "reason", StockTransfersReason.REORG);
+        setField(request, "notes", "Move stock");
+        return request;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Failed to set field " + fieldName, ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of schema decisions
This PR implements WHS-70 to align inventory workflows and schema constraints across `inventory`, `stock_adjustments`, `stock_transfers`, and `stock_movements`.

Key decisions:
- Inventory logical uniqueness now handles nullable dimensions (`location_id`, `batch_id`) using normalized generated columns and a normalized unique constraint.
- `stock_adjustments` constraints are hardened to enforce:
  - `quantity_before >= 0`
  - `quantity_after >= 0`
  - `adjustment_quantity = quantity_after - quantity_before`
  - `adjustment_quantity <> 0`
  - status metadata consistency for pending/approved/rejected states
- `stock_movements` schema and entity mapping are aligned, including `warehouse_id` and nullable reference/location fields expected by the application.
- Added indexes for hot query paths (status/date/inventory lookups).

## Migration strategy + rollback note
### Forward migration
- Added Flyway migration: `V20260404_01__Refactor_inventory_schema_consistency.sql`.
- Migration updates:
  - Replace legacy inventory unique key with normalized uniqueness strategy.
  - Add strict check constraints and metadata checks on `stock_adjustments`.
  - Align `stock_movements` column nullability expectations.
  - Add workflow/query indexes for adjustments/transfers/movements/inventory filters.

### Rollback note
- No automatic down migration is included.
- Rollback requires a manual SQL script to:
  - Drop newly added constraints/indexes/generated columns.
  - Recreate previous unique/index definitions.
- Data compatibility risk is low because this migration is additive/hardening-focused, but rollback should be executed in a maintenance window with backup restore plan.

## Impacted APIs/services
### Controllers
- `StockAdjustmentsController`
- `StockTransfersController`
- `StockMovementsController`

### Services
- `StockAdjustmentsServiceImpl`
  - Implemented create/get/list/search/approve/reject.
  - Enforced workflow transitions and inventory/movement side effects atomically.
- `StockTransfersServiceImpl`
  - Implemented create/get/list/complete/cancel.
  - Enforced same-warehouse location validation, stock availability, and two-sided movement write on completion.
- `StockMovementsServiceImpl`
  - Implemented get/list/by-reference.

### Repositories/Entities/Mappers
- Added row-level locking repository methods for concurrency safety.
- Aligned entity mappings for new schema assumptions and constraints.
- Mappers now derive authoritative stock-adjustment snapshots from `inventory_id`.

## Backward compatibility / breaking changes
- `POST /api/v1/stock-adjustments` remains backward-compatible for legacy payload fields (`product_id`, `warehouse_id`, `location_id`, `batch_id`, `quantity_before`), but authoritative values are now derived from `inventory_id`.
- Breaking change: `StockTransfersStatus` typo fixed from `DAFT` to `DRAFT` to match DB enum and business workflow.

## Test evidence (what passed)
Executed targeted suite:
- `StockAdjustmentsServiceImplTest`
- `StockTransfersServiceImplTest`
- `StockAdjustmentsConstraintIntegrationTest`
- `InventoryOptimisticLockIntegrationTest`

Result: all passed (`BUILD SUCCESS`).

## Residual risks
- Migration uses MySQL-oriented DDL semantics consistent with existing migrations; if a PostgreSQL deployment path is required for this module migration, a dialect-specific migration variant may be needed.
- Destination-inventory creation during highly concurrent transfer completion can still race at first-create; DB uniqueness prevents duplicates, but retry handling can be improved in a follow-up if required.
- Full regression suite was not executed in this PR run; targeted WHS-70 tests passed.