### PR TITLE
feat(category): add WHS-18 common foundation

### DIFF
--- a/src/main/java/org/demo/whs/controller/CategoryController.java
+++ b/src/main/java/org/demo/whs/controller/CategoryController.java
@@ -2,6 +2,8 @@ package org.demo.whs.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.service.CategoryService;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,5 +11,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@Validated
 public class CategoryController {
+
+    private final CategoryService categoryService;
 }

--- a/src/main/java/org/demo/whs/entity/dto/request/Category/CreateCategoryRequest.java
+++ b/src/main/java/org/demo/whs/entity/dto/request/Category/CreateCategoryRequest.java
@@ -1,0 +1,33 @@
+package org.demo.whs.entity.dto.request.Category;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import org.demo.whs.entity.enums.CategoryStatus;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CreateCategoryRequest {
+
+    @NotBlank(message = "Category code is required")
+    @Size(max = 20, message = "Category code must not exceed 20 characters")
+    @Pattern(
+            regexp = "^[A-Z0-9_-]+$",
+            message = "Category code must contain only uppercase letters, numbers, underscores, and hyphens"
+    )
+    private String code;
+
+    @NotBlank(message = "Category name is required")
+    @Size(max = 100, message = "Category name must not exceed 100 characters")
+    private String name;
+
+    @Size(max = 255, message = "Description must not exceed 255 characters")
+    private String description;
+
+    @NotNull(message = "Category status is required")
+    private CategoryStatus status;
+}

--- a/src/main/java/org/demo/whs/entity/dto/request/Category/UpdateCategoryRequest.java
+++ b/src/main/java/org/demo/whs/entity/dto/request/Category/UpdateCategoryRequest.java
@@ -1,0 +1,25 @@
+package org.demo.whs.entity.dto.request.Category;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UpdateCategoryRequest {
+
+    @Size(max = 20, message = "Category code must not exceed 20 characters")
+    @Pattern(
+            regexp = "^[A-Z0-9_-]+$",
+            message = "Category code must contain only uppercase letters, numbers, underscores, and hyphens"
+    )
+    private String code;
+
+    @Size(max = 100, message = "Category name must not exceed 100 characters")
+    private String name;
+
+    @Size(max = 255, message = "Description must not exceed 255 characters")
+    private String description;
+}

--- a/src/main/java/org/demo/whs/entity/dto/request/Category/UpdateCategoryStatusRequest.java
+++ b/src/main/java/org/demo/whs/entity/dto/request/Category/UpdateCategoryStatusRequest.java
@@ -1,0 +1,15 @@
+package org.demo.whs.entity.dto.request.Category;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.demo.whs.entity.enums.CategoryStatus;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UpdateCategoryStatusRequest {
+
+    @NotNull(message = "Category status is required")
+    private CategoryStatus status;
+}

--- a/src/main/java/org/demo/whs/entity/dto/response/Category/CategoryResponse.java
+++ b/src/main/java/org/demo/whs/entity/dto/response/Category/CategoryResponse.java
@@ -1,0 +1,25 @@
+package org.demo.whs.entity.dto.response.Category;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+import org.demo.whs.entity.enums.CategoryStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CategoryResponse {
+
+    private String id;
+    private String code;
+    private String name;
+    private String description;
+    private CategoryStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String createdBy;
+    private String updatedBy;
+}

--- a/src/main/java/org/demo/whs/exception/BadRequestException.java
+++ b/src/main/java/org/demo/whs/exception/BadRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public class BadRequestException extends BaseException {
     public BadRequestException(String message, ErrorCode errorCode) {
-        super(message, errorCode.getMessage(), HttpStatus.BAD_REQUEST);
+        super(errorCode.getCode(), message, HttpStatus.BAD_REQUEST);
     }
 
     public BadRequestException(ErrorCode errorCode) {

--- a/src/main/java/org/demo/whs/exception/ConflictException.java
+++ b/src/main/java/org/demo/whs/exception/ConflictException.java
@@ -1,0 +1,14 @@
+package org.demo.whs.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends BaseException {
+
+    public ConflictException(ErrorCode errorCode) {
+        super(errorCode, HttpStatus.CONFLICT);
+    }
+
+    public ConflictException(String message, ErrorCode errorCode) {
+        super(errorCode.getCode(), message, HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/org/demo/whs/exception/ErrorCode.java
+++ b/src/main/java/org/demo/whs/exception/ErrorCode.java
@@ -59,6 +59,10 @@ public enum ErrorCode {
     PROD_007("PROD_007", "Max stock level must be greater than or equal to min stock level"),
     PROD_008("PROD_008", "Reorder point must be between min and max stock levels"),
 
+    // Category errors
+    CAT_001("CAT_001", "Category not found"),
+    CAT_002("CAT_002", "Category code or name already exists"),
+
     // UnitsOfMeasure errors
     UOM_001("UOM_001", "Unit of Measure not found"),
     UOM_002("UOM_002", "Unit of Measure code already exists"),

--- a/src/main/java/org/demo/whs/exception/NotFoundException.java
+++ b/src/main/java/org/demo/whs/exception/NotFoundException.java
@@ -4,6 +4,10 @@ import org.springframework.http.HttpStatus;
 
 public class NotFoundException extends BaseException {
     public NotFoundException(String message, ErrorCode errorCode) {
-        super(message, errorCode.getMessage(), HttpStatus.NOT_FOUND);
+        super(errorCode.getCode(), message, HttpStatus.NOT_FOUND);
+    }
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/org/demo/whs/mapper/CategoryMapper.java
+++ b/src/main/java/org/demo/whs/mapper/CategoryMapper.java
@@ -1,0 +1,74 @@
+package org.demo.whs.mapper;
+
+import org.demo.whs.entity.Category;
+import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
+import org.demo.whs.entity.dto.response.Category.CategoryResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class CategoryMapper {
+
+    public Category toEntity(CreateCategoryRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        return Category.builder()
+                .code(request.getCode())
+                .name(request.getName())
+                .description(request.getDescription())
+                .status(request.getStatus())
+                .build();
+    }
+
+    public CategoryResponse toResponse(Category entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return CategoryResponse.builder()
+                .id(entity.getId())
+                .code(entity.getCode())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .status(entity.getStatus())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .createdBy(entity.getCreatedBy())
+                .updatedBy(entity.getUpdatedBy())
+                .build();
+    }
+
+    public List<CategoryResponse> toResponseList(List<Category> entities) {
+        if (entities == null || entities.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return entities.stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public void updateEntity(Category entity, UpdateCategoryRequest request) {
+        if (entity == null || request == null) {
+            return;
+        }
+
+        if (request.getCode() != null && !request.getCode().isBlank()) {
+            entity.setCode(request.getCode());
+        }
+
+        if (request.getName() != null && !request.getName().isBlank()) {
+            entity.setName(request.getName());
+        }
+
+        if (request.getDescription() != null) {
+            entity.setDescription(request.getDescription());
+        }
+    }
+}

--- a/src/main/java/org/demo/whs/repository/CategoryRepository.java
+++ b/src/main/java/org/demo/whs/repository/CategoryRepository.java
@@ -1,6 +1,9 @@
 package org.demo.whs.repository;
 
 import org.demo.whs.entity.Category;
+import org.demo.whs.entity.enums.CategoryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +12,14 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, String> {
+
+    boolean existsByCodeIgnoreCase(String code);
+
+    boolean existsByNameIgnoreCase(String name);
+
+    boolean existsByCodeIgnoreCaseAndIdNot(String code, String id);
+
+    boolean existsByNameIgnoreCaseAndIdNot(String name, String id);
+
+    Page<Category> findAllByStatus(CategoryStatus status, Pageable pageable);
 }

--- a/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
@@ -2,6 +2,8 @@ package org.demo.whs.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.mapper.CategoryMapper;
+import org.demo.whs.repository.CategoryRepository;
 import org.demo.whs.service.CategoryService;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +11,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
 }


### PR DESCRIPTION
## Summary
- add common request/response DTOs for Category module
- add `CategoryMapper` for entity-DTO mapping
- extend `CategoryRepository` with reusable query methods
- add `CAT_001`/`CAT_002` error codes and `ConflictException`
- wire `CategoryController` and `CategoryServiceImpl` base dependencies

## Notes
- this PR is the shared base branch for child category API PRs
- tested compile with `./mvnw -DskipTests compile`