### PR TITLE
feat(category): implement WHS-5 create category API

### DIFF
--- a/src/main/java/org/demo/whs/controller/CategoryController.java
+++ b/src/main/java/org/demo/whs/controller/CategoryController.java
@@ -2,10 +2,19 @@ package org.demo.whs.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.BaseResponse;
+import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.service.CategoryService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
 
 @RequestMapping("/api/v1/categories")
 @RestController
@@ -15,4 +24,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController {
 
     private final CategoryService categoryService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<BaseResponse<CategoryResponse>> createCategory(
+            @RequestBody @Valid CreateCategoryRequest request
+    ) {
+        CategoryResponse response = categoryService.createCategory(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(BaseResponse.success(response));
+    }
 }

--- a/src/main/java/org/demo/whs/service/CategoryService.java
+++ b/src/main/java/org/demo/whs/service/CategoryService.java
@@ -1,7 +1,12 @@
 package org.demo.whs.service;
 
+import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.Category.CategoryResponse;
+
 /**
  * Service interface for category-related operations.
  */
 public interface CategoryService {
+
+    CategoryResponse createCategory(CreateCategoryRequest request);
 }

--- a/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
@@ -2,10 +2,16 @@ package org.demo.whs.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.demo.whs.entity.Category;
+import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.Category.CategoryResponse;
+import org.demo.whs.exception.ConflictException;
+import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.mapper.CategoryMapper;
 import org.demo.whs.repository.CategoryRepository;
 import org.demo.whs.service.CategoryService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -14,4 +20,27 @@ public class CategoryServiceImpl implements CategoryService {
 
     private final CategoryRepository categoryRepository;
     private final CategoryMapper categoryMapper;
+
+    @Override
+    @Transactional
+    public CategoryResponse createCategory(CreateCategoryRequest request) {
+        String normalizedCode = request.getCode().trim();
+        String normalizedName = request.getName().trim();
+
+        boolean duplicatedCode = categoryRepository.existsByCodeIgnoreCase(normalizedCode);
+        boolean duplicatedName = categoryRepository.existsByNameIgnoreCase(normalizedName);
+        if (duplicatedCode || duplicatedName) {
+            log.warn("Category code or name already exists, code={}, name={}", normalizedCode, normalizedName);
+            throw new ConflictException(ErrorCode.CAT_002);
+        }
+
+        Category category = categoryMapper.toEntity(request);
+        category.setCode(normalizedCode);
+        category.setName(normalizedName);
+
+        Category savedCategory = categoryRepository.save(category);
+        log.info("Category created successfully, id={}, code={}", savedCategory.getId(), savedCategory.getCode());
+
+        return categoryMapper.toResponse(savedCategory);
+    }
 }

--- a/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
@@ -1,0 +1,102 @@
+package org.demo.whs.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.Category.CategoryResponse;
+import org.demo.whs.entity.enums.CategoryStatus;
+import org.demo.whs.exception.GlobalExceptionHandle;
+import org.demo.whs.service.CategoryService;
+import org.demo.whs.service.RateLimitService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CategoryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import(GlobalExceptionHandle.class)
+@ImportAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        FlywayAutoConfiguration.class
+})
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CategoryService categoryService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @Test
+    @DisplayName("should_CreateCategory_When_RequestIsValid")
+    void should_CreateCategory_When_RequestIsValid() throws Exception {
+        CreateCategoryRequest request = new CreateCategoryRequest();
+        setField(request, "code", "ELEC");
+        setField(request, "name", "Electronics");
+        setField(request, "status", CategoryStatus.ACTIVE);
+
+        CategoryResponse response = CategoryResponse.builder()
+                .id("cat-1")
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+
+        when(categoryService.createCategory(any(CreateCategoryRequest.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/v1/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value("cat-1"))
+                .andExpect(jsonPath("$.data.code").value("ELEC"));
+    }
+
+    @Test
+    @DisplayName("should_ReturnBadRequest_When_CreatePayloadMissingRequiredFields")
+    void should_ReturnBadRequest_When_CreatePayloadMissingRequiredFields() throws Exception {
+        String invalidPayload = """
+                {
+                  "code": "",
+                  "name": "",
+                  "status": null
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidPayload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws ReflectiveOperationException {
+        var field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
@@ -1,0 +1,102 @@
+package org.demo.whs.service.impl;
+
+import org.demo.whs.entity.Category;
+import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.Category.CategoryResponse;
+import org.demo.whs.entity.enums.CategoryStatus;
+import org.demo.whs.exception.ConflictException;
+import org.demo.whs.mapper.CategoryMapper;
+import org.demo.whs.repository.CategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CategoryServiceImpl Unit Tests")
+class CategoryServiceImplTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private CategoryMapper categoryMapper;
+
+    @InjectMocks
+    private CategoryServiceImpl categoryService;
+
+    @Test
+    @DisplayName("should_CreateCategory_When_RequestIsValid")
+    void should_CreateCategory_When_RequestIsValid() {
+        CreateCategoryRequest request = buildCreateRequest("ELEC", "Electronics", CategoryStatus.ACTIVE);
+        Category category = Category.builder()
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        Category savedCategory = Category.builder()
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        savedCategory.setId("cat-1");
+        CategoryResponse expectedResponse = CategoryResponse.builder()
+                .id("cat-1")
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+
+        when(categoryRepository.existsByCodeIgnoreCase("ELEC")).thenReturn(false);
+        when(categoryRepository.existsByNameIgnoreCase("Electronics")).thenReturn(false);
+        when(categoryMapper.toEntity(request)).thenReturn(category);
+        when(categoryRepository.save(category)).thenReturn(savedCategory);
+        when(categoryMapper.toResponse(savedCategory)).thenReturn(expectedResponse);
+
+        CategoryResponse actual = categoryService.createCategory(request);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getId()).isEqualTo("cat-1");
+        assertThat(actual.getCode()).isEqualTo("ELEC");
+        verify(categoryRepository).existsByCodeIgnoreCase("ELEC");
+        verify(categoryRepository).existsByNameIgnoreCase("Electronics");
+        verify(categoryRepository).save(category);
+    }
+
+    @Test
+    @DisplayName("should_ThrowConflictException_When_CodeAlreadyExists")
+    void should_ThrowConflictException_When_CodeAlreadyExists() {
+        CreateCategoryRequest request = buildCreateRequest("ELEC", "Electronics", CategoryStatus.ACTIVE);
+
+        when(categoryRepository.existsByCodeIgnoreCase("ELEC")).thenReturn(true);
+
+        assertThatThrownBy(() -> categoryService.createCategory(request))
+                .isInstanceOf(ConflictException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "CAT_002");
+    }
+
+    private CreateCategoryRequest buildCreateRequest(String code, String name, CategoryStatus status) {
+        CreateCategoryRequest request = new CreateCategoryRequest();
+        try {
+            setField(request, "code", code);
+            setField(request, "name", name);
+            setField(request, "status", status);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Failed to setup test request", ex);
+        }
+        return request;
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws ReflectiveOperationException {
+        var field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `POST /api/v1/categories`
- add duplicate code/name validation and `409 Conflict` handling
- add service and controller tests for create flow and validation errors

## Test
- `./mvnw -Dtest=CategoryServiceImplTest,CategoryControllerTest test`