### PR TITLE
feat(category): implement WHS-6 list categories API

### DIFF
--- a/src/main/java/org/demo/whs/controller/CategoryController.java
+++ b/src/main/java/org/demo/whs/controller/CategoryController.java
@@ -4,15 +4,22 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
 import org.demo.whs.entity.dto.response.BaseResponse;
+import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
+import org.demo.whs.entity.enums.CategoryStatus;
 import org.demo.whs.service.CategoryService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 
@@ -34,5 +41,15 @@ public class CategoryController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(BaseResponse.success(response));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    public ResponseEntity<BaseResponse<PageResponse<CategoryResponse>>> getCategories(
+            @RequestParam(required = false) CategoryStatus status,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        PageResponse<CategoryResponse> response = categoryService.getCategories(status, pageable);
+        return ResponseEntity.ok(BaseResponse.success(response));
     }
 }

--- a/src/main/java/org/demo/whs/controller/CategoryController.java
+++ b/src/main/java/org/demo/whs/controller/CategoryController.java
@@ -16,12 +16,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 
 @RequestMapping("/api/v1/categories")
 @RestController
@@ -29,6 +31,9 @@ import jakarta.validation.Valid;
 @Slf4j
 @Validated
 public class CategoryController {
+
+    private static final String UUID_PATTERN =
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$";
 
     private final CategoryService categoryService;
 
@@ -50,6 +55,16 @@ public class CategoryController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         PageResponse<CategoryResponse> response = categoryService.getCategories(status, pageable);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    public ResponseEntity<BaseResponse<CategoryResponse>> getCategoryById(
+            @PathVariable
+            @Pattern(regexp = UUID_PATTERN, message = "Invalid category id format") String id
+    ) {
+        CategoryResponse response = categoryService.getCategoryById(id);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 }

--- a/src/main/java/org/demo/whs/exception/GlobalExceptionHandle.java
+++ b/src/main/java/org/demo/whs/exception/GlobalExceptionHandle.java
@@ -8,6 +8,7 @@ import org.demo.whs.entity.dto.response.RateLimitErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -92,6 +93,15 @@ public class GlobalExceptionHandle {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(BaseResponse.error(ErrorCode.COM_003.getCode(), ErrorCode.COM_003.getMessage(), null));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException ex) {
+        log.warn("Invalid request parameter: parameter={}, value={}", ex.getName(), ex.getValue());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(BaseResponse.error(ErrorCode.COM_001.getCode(), ErrorCode.COM_001.getMessage(), null));
     }
 
     /**

--- a/src/main/java/org/demo/whs/service/CategoryService.java
+++ b/src/main/java/org/demo/whs/service/CategoryService.java
@@ -1,7 +1,10 @@
 package org.demo.whs.service;
 
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
+import org.demo.whs.entity.enums.CategoryStatus;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Service interface for category-related operations.
@@ -9,4 +12,6 @@ import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 public interface CategoryService {
 
     CategoryResponse createCategory(CreateCategoryRequest request);
+
+    PageResponse<CategoryResponse> getCategories(CategoryStatus status, Pageable pageable);
 }

--- a/src/main/java/org/demo/whs/service/CategoryService.java
+++ b/src/main/java/org/demo/whs/service/CategoryService.java
@@ -14,4 +14,6 @@ public interface CategoryService {
     CategoryResponse createCategory(CreateCategoryRequest request);
 
     PageResponse<CategoryResponse> getCategories(CategoryStatus status, Pageable pageable);
+
+    CategoryResponse getCategoryById(String id);
 }

--- a/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
@@ -4,14 +4,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.Category;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
+import org.demo.whs.entity.enums.CategoryStatus;
+import org.demo.whs.exception.BadRequestException;
 import org.demo.whs.exception.ConflictException;
 import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.mapper.CategoryMapper;
 import org.demo.whs.repository.CategoryRepository;
 import org.demo.whs.service.CategoryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Slf4j
@@ -42,5 +49,24 @@ public class CategoryServiceImpl implements CategoryService {
         log.info("Category created successfully, id={}, code={}", savedCategory.getId(), savedCategory.getCode());
 
         return categoryMapper.toResponse(savedCategory);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<CategoryResponse> getCategories(CategoryStatus status, Pageable pageable) {
+        validatePageable(pageable);
+
+        Page<Category> categoryPage = status == null
+                ? categoryRepository.findAll(pageable)
+                : categoryRepository.findAllByStatus(status, pageable);
+
+        List<CategoryResponse> responses = categoryMapper.toResponseList(categoryPage.getContent());
+        return PageResponse.from(categoryPage, responses);
+    }
+
+    private void validatePageable(Pageable pageable) {
+        if (pageable.getPageNumber() < 0 || pageable.getPageSize() <= 0 || pageable.getPageSize() > 100) {
+            throw new BadRequestException(ErrorCode.COM_001);
+        }
     }
 }

--- a/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
@@ -10,6 +10,7 @@ import org.demo.whs.entity.enums.CategoryStatus;
 import org.demo.whs.exception.BadRequestException;
 import org.demo.whs.exception.ConflictException;
 import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.exception.NotFoundException;
 import org.demo.whs.mapper.CategoryMapper;
 import org.demo.whs.repository.CategoryRepository;
 import org.demo.whs.service.CategoryService;
@@ -62,6 +63,14 @@ public class CategoryServiceImpl implements CategoryService {
 
         List<CategoryResponse> responses = categoryMapper.toResponseList(categoryPage.getContent());
         return PageResponse.from(categoryPage, responses);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CategoryResponse getCategoryById(String id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Category not found", ErrorCode.CAT_001));
+        return categoryMapper.toResponse(category);
     }
 
     private void validatePageable(Pageable pageable) {

--- a/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
@@ -6,6 +6,8 @@ import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
 import org.demo.whs.exception.GlobalExceptionHandle;
+import org.demo.whs.exception.NotFoundException;
+import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.service.CategoryService;
 import org.demo.whs.service.RateLimitService;
 import org.junit.jupiter.api.DisplayName;
@@ -136,6 +138,44 @@ class CategoryControllerTest {
                         .param("status", "INVALID"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
+    }
+
+    @Test
+    @DisplayName("should_GetCategoryById_When_CategoryExists")
+    void should_GetCategoryById_When_CategoryExists() throws Exception {
+        CategoryResponse response = CategoryResponse.builder()
+                .id("7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+
+        when(categoryService.getCategoryById("7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/categories/{id}", "7c9e6679-7425-40de-944b-e07fc1f90ae7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value("7c9e6679-7425-40de-944b-e07fc1f90ae7"));
+    }
+
+    @Test
+    @DisplayName("should_ReturnNotFound_When_CategoryDoesNotExist")
+    void should_ReturnNotFound_When_CategoryDoesNotExist() throws Exception {
+        when(categoryService.getCategoryById("7c9e6679-7425-40de-944b-e07fc1f90ae7"))
+                .thenThrow(new NotFoundException("Category not found", ErrorCode.CAT_001));
+
+        mockMvc.perform(get("/api/v1/categories/{id}", "7c9e6679-7425-40de-944b-e07fc1f90ae7"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error_code").value("CAT_001"))
+                .andExpect(jsonPath("$.message").value("Category not found"));
+    }
+
+    @Test
+    @DisplayName("should_ReturnBadRequest_When_CategoryIdIsInvalid")
+    void should_ReturnBadRequest_When_CategoryIdIsInvalid() throws Exception {
+        mockMvc.perform(get("/api/v1/categories/{id}", "invalid-id"))
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error_code").value("COM_001"));
     }
 

--- a/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
@@ -2,6 +2,7 @@ package org.demo.whs.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
 import org.demo.whs.exception.GlobalExceptionHandle;
@@ -21,8 +22,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -89,6 +93,47 @@ class CategoryControllerTest {
         mockMvc.perform(post("/api/v1/categories")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidPayload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
+    }
+
+    @Test
+    @DisplayName("should_GetCategories_When_RequestIsValid")
+    void should_GetCategories_When_RequestIsValid() throws Exception {
+        CategoryResponse category = CategoryResponse.builder()
+                .id("cat-1")
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+
+        PageResponse<CategoryResponse> pageResponse = PageResponse.<CategoryResponse>builder()
+                .content(List.of(category))
+                .page(0)
+                .size(10)
+                .totalElements(1L)
+                .totalPages(1)
+                .isFirst(true)
+                .isLast(true)
+                .build();
+
+        when(categoryService.getCategories(any(), any())).thenReturn(pageResponse);
+
+        mockMvc.perform(get("/api/v1/categories")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("status", "ACTIVE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content[0].id").value("cat-1"));
+    }
+
+    @Test
+    @DisplayName("should_ReturnBadRequest_When_StatusFilterIsInvalid")
+    void should_ReturnBadRequest_When_StatusFilterIsInvalid() throws Exception {
+        mockMvc.perform(get("/api/v1/categories")
+                        .param("status", "INVALID"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error_code").value("COM_001"));

--- a/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
@@ -2,8 +2,10 @@ package org.demo.whs.service.impl;
 
 import org.demo.whs.entity.Category;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
+import org.demo.whs.exception.BadRequestException;
 import org.demo.whs.exception.ConflictException;
 import org.demo.whs.mapper.CategoryMapper;
 import org.demo.whs.repository.CategoryRepository;
@@ -13,6 +15,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -80,6 +89,46 @@ class CategoryServiceImplTest {
         assertThatThrownBy(() -> categoryService.createCategory(request))
                 .isInstanceOf(ConflictException.class)
                 .hasFieldOrPropertyWithValue("errorCode", "CAT_002");
+    }
+
+    @Test
+    @DisplayName("should_GetCategories_When_StatusFilterProvided")
+    void should_GetCategories_When_StatusFilterProvided() {
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Category category = Category.builder()
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        category.setId("cat-1");
+
+        Page<Category> page = new PageImpl<>(List.of(category), pageable, 1);
+        CategoryResponse mapped = CategoryResponse.builder()
+                .id("cat-1")
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+
+        when(categoryRepository.findAllByStatus(CategoryStatus.ACTIVE, pageable)).thenReturn(page);
+        when(categoryMapper.toResponseList(page.getContent())).thenReturn(List.of(mapped));
+
+        PageResponse<CategoryResponse> actual = categoryService.getCategories(CategoryStatus.ACTIVE, pageable);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getContent()).hasSize(1);
+        assertThat(actual.getContent().get(0).getId()).isEqualTo("cat-1");
+        verify(categoryRepository).findAllByStatus(CategoryStatus.ACTIVE, pageable);
+    }
+
+    @Test
+    @DisplayName("should_ThrowBadRequest_When_PageSizeExceedsLimit")
+    void should_ThrowBadRequest_When_PageSizeExceedsLimit() {
+        Pageable pageable = PageRequest.of(0, 101);
+
+        assertThatThrownBy(() -> categoryService.getCategories(null, pageable))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "COM_001");
     }
 
     private CreateCategoryRequest buildCreateRequest(String code, String name, CategoryStatus status) {

--- a/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
@@ -7,6 +7,7 @@ import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
 import org.demo.whs.exception.BadRequestException;
 import org.demo.whs.exception.ConflictException;
+import org.demo.whs.exception.NotFoundException;
 import org.demo.whs.mapper.CategoryMapper;
 import org.demo.whs.repository.CategoryRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -129,6 +131,42 @@ class CategoryServiceImplTest {
         assertThatThrownBy(() -> categoryService.getCategories(null, pageable))
                 .isInstanceOf(BadRequestException.class)
                 .hasFieldOrPropertyWithValue("errorCode", "COM_001");
+    }
+
+    @Test
+    @DisplayName("should_GetCategoryById_When_CategoryExists")
+    void should_GetCategoryById_When_CategoryExists() {
+        Category category = Category.builder()
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        category.setId("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+
+        CategoryResponse mapped = CategoryResponse.builder()
+                .id("7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+
+        when(categoryRepository.findById("7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(Optional.of(category));
+        when(categoryMapper.toResponse(category)).thenReturn(mapped);
+
+        CategoryResponse actual = categoryService.getCategoryById("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getId()).isEqualTo("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+    }
+
+    @Test
+    @DisplayName("should_ThrowNotFoundException_When_CategoryDoesNotExist")
+    void should_ThrowNotFoundException_When_CategoryDoesNotExist() {
+        when(categoryRepository.findById("7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> categoryService.getCategoryById("7c9e6679-7425-40de-944b-e07fc1f90ae7"))
+                .isInstanceOf(NotFoundException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "CAT_001");
     }
 
     private CreateCategoryRequest buildCreateRequest(String code, String name, CategoryStatus status) {


### PR DESCRIPTION
## Summary
- implement `GET /api/v1/categories` with pagination, sorting and status filter
- add pageable validation and invalid enum query handling (`400`)
- add service and controller tests for list and invalid status cases

## Test
- `./mvnw -Dtest=CategoryServiceImplTest,CategoryControllerTest test`