### PR TITLE
feat(category): implement WHS-8 update category API

### DIFF
--- a/src/main/java/org/demo/whs/controller/CategoryController.java
+++ b/src/main/java/org/demo/whs/controller/CategoryController.java
@@ -3,6 +3,7 @@ package org.demo.whs.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
 import org.demo.whs.entity.dto.response.BaseResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
@@ -18,6 +19,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -65,6 +67,17 @@ public class CategoryController {
             @Pattern(regexp = UUID_PATTERN, message = "Invalid category id format") String id
     ) {
         CategoryResponse response = categoryService.getCategoryById(id);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<BaseResponse<CategoryResponse>> updateCategory(
+            @PathVariable
+            @Pattern(regexp = UUID_PATTERN, message = "Invalid category id format") String id,
+            @RequestBody @Valid UpdateCategoryRequest request
+    ) {
+        CategoryResponse response = categoryService.updateCategory(id, request);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 }

--- a/src/main/java/org/demo/whs/mapper/CategoryMapper.java
+++ b/src/main/java/org/demo/whs/mapper/CategoryMapper.java
@@ -60,11 +60,11 @@ public class CategoryMapper {
         }
 
         if (request.getCode() != null && !request.getCode().isBlank()) {
-            entity.setCode(request.getCode());
+            entity.setCode(request.getCode().trim());
         }
 
         if (request.getName() != null && !request.getName().isBlank()) {
-            entity.setName(request.getName());
+            entity.setName(request.getName().trim());
         }
 
         if (request.getDescription() != null) {

--- a/src/main/java/org/demo/whs/service/CategoryService.java
+++ b/src/main/java/org/demo/whs/service/CategoryService.java
@@ -1,6 +1,7 @@
 package org.demo.whs.service;
 
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
@@ -16,4 +17,6 @@ public interface CategoryService {
     PageResponse<CategoryResponse> getCategories(CategoryStatus status, Pageable pageable);
 
     CategoryResponse getCategoryById(String id);
+
+    CategoryResponse updateCategory(String id, UpdateCategoryRequest request);
 }

--- a/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.Category;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
@@ -73,9 +74,49 @@ public class CategoryServiceImpl implements CategoryService {
         return categoryMapper.toResponse(category);
     }
 
+    @Override
+    @Transactional
+    public CategoryResponse updateCategory(String id, UpdateCategoryRequest request) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Category not found", ErrorCode.CAT_001));
+
+        if (!hasAnyUpdatableField(request)) {
+            throw new BadRequestException(ErrorCode.COM_001);
+        }
+
+        String normalizedCode = normalize(request.getCode());
+        String normalizedName = normalize(request.getName());
+
+        if (normalizedCode != null && categoryRepository.existsByCodeIgnoreCaseAndIdNot(normalizedCode, id)) {
+            throw new ConflictException(ErrorCode.CAT_002);
+        }
+
+        if (normalizedName != null && categoryRepository.existsByNameIgnoreCaseAndIdNot(normalizedName, id)) {
+            throw new ConflictException(ErrorCode.CAT_002);
+        }
+
+        categoryMapper.updateEntity(category, request);
+        Category updatedCategory = categoryRepository.save(category);
+        return categoryMapper.toResponse(updatedCategory);
+    }
+
     private void validatePageable(Pageable pageable) {
         if (pageable.getPageNumber() < 0 || pageable.getPageSize() <= 0 || pageable.getPageSize() > 100) {
             throw new BadRequestException(ErrorCode.COM_001);
         }
+    }
+
+    private boolean hasAnyUpdatableField(UpdateCategoryRequest request) {
+        return normalize(request.getCode()) != null
+                || normalize(request.getName()) != null
+                || request.getDescription() != null;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
@@ -2,9 +2,11 @@ package org.demo.whs.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
+import org.demo.whs.exception.ConflictException;
 import org.demo.whs.exception.GlobalExceptionHandle;
 import org.demo.whs.exception.NotFoundException;
 import org.demo.whs.exception.ErrorCode;
@@ -30,6 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -175,6 +178,63 @@ class CategoryControllerTest {
     @DisplayName("should_ReturnBadRequest_When_CategoryIdIsInvalid")
     void should_ReturnBadRequest_When_CategoryIdIsInvalid() throws Exception {
         mockMvc.perform(get("/api/v1/categories/{id}", "invalid-id"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
+    }
+
+    @Test
+    @DisplayName("should_UpdateCategory_When_RequestIsValid")
+    void should_UpdateCategory_When_RequestIsValid() throws Exception {
+        UpdateCategoryRequest request = new UpdateCategoryRequest();
+        setField(request, "code", "ELEC-NEW");
+        setField(request, "name", "Electronics New");
+        setField(request, "description", "Updated desc");
+
+        CategoryResponse response = CategoryResponse.builder()
+                .id("7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                .code("ELEC-NEW")
+                .name("Electronics New")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+
+        when(categoryService.updateCategory(any(), any(UpdateCategoryRequest.class))).thenReturn(response);
+
+        mockMvc.perform(put("/api/v1/categories/{id}", "7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.code").value("ELEC-NEW"));
+    }
+
+    @Test
+    @DisplayName("should_ReturnConflict_When_UpdateCategoryDuplicated")
+    void should_ReturnConflict_When_UpdateCategoryDuplicated() throws Exception {
+        UpdateCategoryRequest request = new UpdateCategoryRequest();
+        setField(request, "code", "ELEC");
+
+        when(categoryService.updateCategory(any(), any(UpdateCategoryRequest.class)))
+                .thenThrow(new ConflictException(ErrorCode.CAT_002));
+
+        mockMvc.perform(put("/api/v1/categories/{id}", "7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error_code").value("CAT_002"));
+    }
+
+    @Test
+    @DisplayName("should_ReturnBadRequest_When_UpdatePayloadInvalid")
+    void should_ReturnBadRequest_When_UpdatePayloadInvalid() throws Exception {
+        String invalidPayload = """
+                {
+                  "code": "invalid code with spaces"
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/categories/{id}", "7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidPayload))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error_code").value("COM_001"));
     }

--- a/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
@@ -2,6 +2,7 @@ package org.demo.whs.service.impl;
 
 import org.demo.whs.entity.Category;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
@@ -167,6 +168,95 @@ class CategoryServiceImplTest {
         assertThatThrownBy(() -> categoryService.getCategoryById("7c9e6679-7425-40de-944b-e07fc1f90ae7"))
                 .isInstanceOf(NotFoundException.class)
                 .hasFieldOrPropertyWithValue("errorCode", "CAT_001");
+    }
+
+    @Test
+    @DisplayName("should_UpdateCategory_When_RequestIsValid")
+    void should_UpdateCategory_When_RequestIsValid() {
+        UpdateCategoryRequest request = new UpdateCategoryRequest();
+        try {
+            setField(request, "code", "ELEC-NEW");
+            setField(request, "name", "Electronics New");
+            setField(request, "description", "Updated desc");
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        Category existing = Category.builder()
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        existing.setId("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+
+        Category updated = Category.builder()
+                .code("ELEC-NEW")
+                .name("Electronics New")
+                .description("Updated desc")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        updated.setId("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+
+        CategoryResponse mapped = CategoryResponse.builder()
+                .id("7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                .code("ELEC-NEW")
+                .name("Electronics New")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+
+        when(categoryRepository.findById("7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(Optional.of(existing));
+        when(categoryRepository.existsByCodeIgnoreCaseAndIdNot("ELEC-NEW", "7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(false);
+        when(categoryRepository.existsByNameIgnoreCaseAndIdNot("Electronics New", "7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(false);
+        when(categoryRepository.save(existing)).thenReturn(updated);
+        when(categoryMapper.toResponse(updated)).thenReturn(mapped);
+
+        CategoryResponse actual = categoryService.updateCategory("7c9e6679-7425-40de-944b-e07fc1f90ae7", request);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getCode()).isEqualTo("ELEC-NEW");
+        verify(categoryMapper).updateEntity(existing, request);
+    }
+
+    @Test
+    @DisplayName("should_ThrowConflictException_When_UpdatingToDuplicatedCode")
+    void should_ThrowConflictException_When_UpdatingToDuplicatedCode() {
+        UpdateCategoryRequest request = new UpdateCategoryRequest();
+        try {
+            setField(request, "code", "ELEC");
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        Category existing = Category.builder()
+                .code("OLD")
+                .name("Old Name")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        existing.setId("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+
+        when(categoryRepository.findById("7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(Optional.of(existing));
+        when(categoryRepository.existsByCodeIgnoreCaseAndIdNot("ELEC", "7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(true);
+
+        assertThatThrownBy(() -> categoryService.updateCategory("7c9e6679-7425-40de-944b-e07fc1f90ae7", request))
+                .isInstanceOf(ConflictException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "CAT_002");
+    }
+
+    @Test
+    @DisplayName("should_ThrowBadRequest_When_UpdatePayloadHasNoFields")
+    void should_ThrowBadRequest_When_UpdatePayloadHasNoFields() {
+        UpdateCategoryRequest request = new UpdateCategoryRequest();
+        Category existing = Category.builder()
+                .code("OLD")
+                .name("Old Name")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        existing.setId("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+        when(categoryRepository.findById("7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> categoryService.updateCategory("7c9e6679-7425-40de-944b-e07fc1f90ae7", request))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "COM_001");
     }
 
     private CreateCategoryRequest buildCreateRequest(String code, String name, CategoryStatus status) {


### PR DESCRIPTION
## Summary
- implement `PUT /api/v1/categories/{id}`
- add duplicate code/name checks on update and return `409` (`CAT_002`)
- validate empty update payload and invalid request fields (`400`)
- add service and controller tests for success/conflict/bad-request/not-found

## Test
- `./mvnw -Dtest=CategoryServiceImplTest,CategoryControllerTest test`