### PR TITLE
feat(category): implement WHS-9 update category status API

### DIFF
--- a/src/main/java/org/demo/whs/controller/CategoryController.java
+++ b/src/main/java/org/demo/whs/controller/CategoryController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
 import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryStatusRequest;
 import org.demo.whs.entity.dto.response.BaseResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
@@ -18,6 +19,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -78,6 +80,17 @@ public class CategoryController {
             @RequestBody @Valid UpdateCategoryRequest request
     ) {
         CategoryResponse response = categoryService.updateCategory(id, request);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<BaseResponse<CategoryResponse>> updateCategoryStatus(
+            @PathVariable
+            @Pattern(regexp = UUID_PATTERN, message = "Invalid category id format") String id,
+            @RequestBody @Valid UpdateCategoryStatusRequest request
+    ) {
+        CategoryResponse response = categoryService.updateCategoryStatus(id, request);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 }

--- a/src/main/java/org/demo/whs/service/CategoryService.java
+++ b/src/main/java/org/demo/whs/service/CategoryService.java
@@ -2,6 +2,7 @@ package org.demo.whs.service;
 
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
 import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryStatusRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
@@ -19,4 +20,6 @@ public interface CategoryService {
     CategoryResponse getCategoryById(String id);
 
     CategoryResponse updateCategory(String id, UpdateCategoryRequest request);
+
+    CategoryResponse updateCategoryStatus(String id, UpdateCategoryStatusRequest request);
 }

--- a/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/CategoryServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.Category;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
 import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryStatusRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
@@ -96,6 +97,17 @@ public class CategoryServiceImpl implements CategoryService {
         }
 
         categoryMapper.updateEntity(category, request);
+        Category updatedCategory = categoryRepository.save(category);
+        return categoryMapper.toResponse(updatedCategory);
+    }
+
+    @Override
+    @Transactional
+    public CategoryResponse updateCategoryStatus(String id, UpdateCategoryStatusRequest request) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Category not found", ErrorCode.CAT_001));
+
+        category.setStatus(request.getStatus());
         Category updatedCategory = categoryRepository.save(category);
         return categoryMapper.toResponse(updatedCategory);
     }

--- a/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/CategoryControllerTest.java
@@ -3,6 +3,7 @@ package org.demo.whs.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
 import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryStatusRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
@@ -31,6 +32,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -233,6 +235,45 @@ class CategoryControllerTest {
                 """;
 
         mockMvc.perform(put("/api/v1/categories/{id}", "7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidPayload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
+    }
+
+    @Test
+    @DisplayName("should_UpdateCategoryStatus_When_RequestIsValid")
+    void should_UpdateCategoryStatus_When_RequestIsValid() throws Exception {
+        UpdateCategoryStatusRequest request = new UpdateCategoryStatusRequest();
+        setField(request, "status", CategoryStatus.INACTIVE);
+
+        CategoryResponse response = CategoryResponse.builder()
+                .id("7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.INACTIVE)
+                .build();
+
+        when(categoryService.updateCategoryStatus(any(), any(UpdateCategoryStatusRequest.class))).thenReturn(response);
+
+        mockMvc.perform(patch("/api/v1/categories/{id}/status", "7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("INACTIVE"));
+    }
+
+    @Test
+    @DisplayName("should_ReturnBadRequest_When_StatusPayloadIsInvalid")
+    void should_ReturnBadRequest_When_StatusPayloadIsInvalid() throws Exception {
+        String invalidPayload = """
+                {
+                  "status": null
+                }
+                """;
+
+        mockMvc.perform(patch("/api/v1/categories/{id}/status", "7c9e6679-7425-40de-944b-e07fc1f90ae7")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidPayload))
                 .andExpect(status().isBadRequest())

--- a/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/CategoryServiceImplTest.java
@@ -3,6 +3,7 @@ package org.demo.whs.service.impl;
 import org.demo.whs.entity.Category;
 import org.demo.whs.entity.dto.request.Category.CreateCategoryRequest;
 import org.demo.whs.entity.dto.request.Category.UpdateCategoryRequest;
+import org.demo.whs.entity.dto.request.Category.UpdateCategoryStatusRequest;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.dto.response.Category.CategoryResponse;
 import org.demo.whs.entity.enums.CategoryStatus;
@@ -257,6 +258,64 @@ class CategoryServiceImplTest {
         assertThatThrownBy(() -> categoryService.updateCategory("7c9e6679-7425-40de-944b-e07fc1f90ae7", request))
                 .isInstanceOf(BadRequestException.class)
                 .hasFieldOrPropertyWithValue("errorCode", "COM_001");
+    }
+
+    @Test
+    @DisplayName("should_UpdateCategoryStatus_When_RequestIsValid")
+    void should_UpdateCategoryStatus_When_RequestIsValid() {
+        UpdateCategoryStatusRequest request = new UpdateCategoryStatusRequest();
+        try {
+            setField(request, "status", CategoryStatus.INACTIVE);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        Category existing = Category.builder()
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.ACTIVE)
+                .build();
+        existing.setId("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+
+        Category updated = Category.builder()
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.INACTIVE)
+                .build();
+        updated.setId("7c9e6679-7425-40de-944b-e07fc1f90ae7");
+
+        CategoryResponse mapped = CategoryResponse.builder()
+                .id("7c9e6679-7425-40de-944b-e07fc1f90ae7")
+                .code("ELEC")
+                .name("Electronics")
+                .status(CategoryStatus.INACTIVE)
+                .build();
+
+        when(categoryRepository.findById("7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(Optional.of(existing));
+        when(categoryRepository.save(existing)).thenReturn(updated);
+        when(categoryMapper.toResponse(updated)).thenReturn(mapped);
+
+        CategoryResponse actual = categoryService.updateCategoryStatus("7c9e6679-7425-40de-944b-e07fc1f90ae7", request);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getStatus()).isEqualTo(CategoryStatus.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("should_ThrowNotFoundException_When_UpdatingStatusOfMissingCategory")
+    void should_ThrowNotFoundException_When_UpdatingStatusOfMissingCategory() {
+        UpdateCategoryStatusRequest request = new UpdateCategoryStatusRequest();
+        try {
+            setField(request, "status", CategoryStatus.INACTIVE);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        when(categoryRepository.findById("7c9e6679-7425-40de-944b-e07fc1f90ae7")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> categoryService.updateCategoryStatus("7c9e6679-7425-40de-944b-e07fc1f90ae7", request))
+                .isInstanceOf(NotFoundException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "CAT_001");
     }
 
     private CreateCategoryRequest buildCreateRequest(String code, String name, CategoryStatus status) {


### PR DESCRIPTION
## Summary
- implement `PATCH /api/v1/categories/{id}/status`
- update category status with validation and not-found handling
- add service and controller tests for success and invalid payload

## Test
- `./mvnw -Dtest=CategoryServiceImplTest,CategoryControllerTest test`