### PR TITLE
[WHS-71] Fix business partner error handling and transaction boundaries

### DIFF
--- a/src/main/java/org/demo/whs/service/impl/BusinessPartnerImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/BusinessPartnerImpl.java
@@ -7,11 +7,15 @@ import org.demo.whs.entity.dto.request.BusinessPartner.BusinessPartnerRequest;
 import org.demo.whs.entity.dto.request.BusinessPartner.UpdateBusinessPartnerRequest;
 import org.demo.whs.entity.dto.response.BusinessPartner.BusinessPartnerResponse;
 import org.demo.whs.entity.enums.BusinessPartnerStatus;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ConflictException;
 import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.exception.NotFoundException;
 import org.demo.whs.mapper.BusinessPartnerMapper;
 import org.demo.whs.repository.BusinessPartnersRepository;
 import org.demo.whs.service.BusinessPartnerService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -36,6 +40,7 @@ public class BusinessPartnerImpl implements BusinessPartnerService {
      * Retrieve all business partners.
      */
     @Override
+    @Transactional(readOnly = true)
     public List<BusinessPartnerResponse> getAll() {
         log.info("[SERVICE][GET_ALL] Fetching all business partners");
 
@@ -50,13 +55,14 @@ public class BusinessPartnerImpl implements BusinessPartnerService {
      * Retrieve a business partner by its identifier.
      */
     @Override
+    @Transactional(readOnly = true)
     public BusinessPartnerResponse getById(String id) {
         log.info("[SERVICE][GET_BY_ID] Start, id={}", id);
 
         BusinessPartners entity = repository.findById(id)
                 .orElseThrow(() -> {
                     log.warn("[SERVICE][GET_BY_ID] Not found, id={}", id);
-                    return new RuntimeException(ErrorCode.BP_001.getCode());
+                    return new NotFoundException(ErrorCode.BP_001);
                 });
 
 //        if (entity.getStatus() == BusinessPartnerStatus.INACTIVE) {
@@ -74,12 +80,13 @@ public class BusinessPartnerImpl implements BusinessPartnerService {
      * Create a new business partner.
      */
     @Override
+    @Transactional
     public BusinessPartnerResponse create(BusinessPartnerRequest request) {
         log.info("[SERVICE][CREATE] Start, code={}", request.getCode());
 
         if (repository.existsByCode(request.getCode())) {
             log.warn("[SERVICE][CREATE] Code already exists, code={}", request.getCode());
-            throw new RuntimeException(ErrorCode.BP_002.getCode());
+            throw new ConflictException(ErrorCode.BP_002);
         }
 
         BusinessPartners entity = mapper.toEntity(request);
@@ -95,13 +102,14 @@ public class BusinessPartnerImpl implements BusinessPartnerService {
      * Update an existing business partner.
      */
     @Override
+    @Transactional
     public BusinessPartnerResponse update(String id, UpdateBusinessPartnerRequest request) {
         log.info("[SERVICE][UPDATE] Start, id={}", id);
 
         BusinessPartners entity = repository.findById(id)
                 .orElseThrow(() -> {
                     log.warn("[SERVICE][UPDATE] Not found, id={}", id);
-                    return new RuntimeException(ErrorCode.BP_001.getCode());
+                    return new NotFoundException(ErrorCode.BP_001);
                 });
 
         mapper.updateEntity(entity, request);
@@ -117,13 +125,14 @@ public class BusinessPartnerImpl implements BusinessPartnerService {
      * Soft delete a business partner.
      */
     @Override
+    @Transactional
     public void delete(String id) {
         log.info("[SERVICE][DELETE] Start, id={}", id);
 
         BusinessPartners entity = repository.findById(id)
                 .orElseThrow(() -> {
                     log.warn("[SERVICE][DELETE] Not found, id={}", id);
-                    return new RuntimeException(ErrorCode.BP_001.getCode());
+                    return new NotFoundException(ErrorCode.BP_001);
                 });
 
         entity.setStatus(BusinessPartnerStatus.INACTIVE);
@@ -137,22 +146,23 @@ public class BusinessPartnerImpl implements BusinessPartnerService {
      * Change the status of a business partner.
      */
     @Override
+    @Transactional
     public BusinessPartnerResponse changeStatus(String id, String status) {
         log.info("[SERVICE][CHANGE_STATUS] Start, id={}, status={}", id, status);
 
         BusinessPartners entity = repository.findById(id)
                 .orElseThrow(() -> {
                     log.warn("[SERVICE][CHANGE_STATUS] Not found, id={}", id);
-                    return new RuntimeException(ErrorCode.BP_001.getCode());
+                    return new NotFoundException(ErrorCode.BP_001);
                 });
 
         try {
             entity.setStatus(
                     BusinessPartnerStatus.valueOf(status.toUpperCase())
             );
-        } catch (IllegalArgumentException ex) {
+        } catch (IllegalArgumentException | NullPointerException ex) {
             log.warn("[SERVICE][CHANGE_STATUS] Invalid status={}, id={}", status, id);
-            throw new RuntimeException(ErrorCode.BP_003.getCode());
+            throw new BadRequestException(ErrorCode.BP_003);
         }
 
         repository.save(entity);

--- a/src/test/java/org/demo/whs/service/impl/BusinessPartnerImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/BusinessPartnerImplTest.java
@@ -1,0 +1,100 @@
+package org.demo.whs.service.impl;
+
+import org.demo.whs.entity.BusinessPartners;
+import org.demo.whs.entity.dto.request.BusinessPartner.BusinessPartnerRequest;
+import org.demo.whs.entity.enums.BusinessPartnerStatus;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ConflictException;
+import org.demo.whs.exception.NotFoundException;
+import org.demo.whs.mapper.BusinessPartnerMapper;
+import org.demo.whs.repository.BusinessPartnersRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BusinessPartnerImpl Unit Tests")
+class BusinessPartnerImplTest {
+
+    @Mock
+    private BusinessPartnersRepository repository;
+
+    @Mock
+    private BusinessPartnerMapper mapper;
+
+    @InjectMocks
+    private BusinessPartnerImpl service;
+
+    @Test
+    @DisplayName("should_ThrowNotFoundException_When_GetByIdWithUnknownId")
+    void should_ThrowNotFoundException_When_GetByIdWithUnknownId() {
+        when(repository.findById("bp-unknown")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getById("bp-unknown"))
+                .isInstanceOf(NotFoundException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "BP_001");
+    }
+
+    @Test
+    @DisplayName("should_ThrowConflictException_When_CreateWithDuplicateCode")
+    void should_ThrowConflictException_When_CreateWithDuplicateCode() {
+        BusinessPartnerRequest request = BusinessPartnerRequest.builder()
+                .code("BP-001")
+                .name("Partner A")
+                .type("SUPPLIER")
+                .status("ACTIVE")
+                .build();
+
+        when(repository.existsByCode("BP-001")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.create(request))
+                .isInstanceOf(ConflictException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "BP_002");
+
+        verify(repository, never()).save(any(BusinessPartners.class));
+    }
+
+    @Test
+    @DisplayName("should_ThrowBadRequestException_When_ChangeStatusWithInvalidStatus")
+    void should_ThrowBadRequestException_When_ChangeStatusWithInvalidStatus() {
+        BusinessPartners entity = new BusinessPartners();
+        entity.setId("bp-001");
+        entity.setCode("BP-001");
+        entity.setStatus(BusinessPartnerStatus.ACTIVE);
+
+        when(repository.findById("bp-001")).thenReturn(Optional.of(entity));
+
+        assertThatThrownBy(() -> service.changeStatus("bp-001", "NOT_A_STATUS"))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "BP_003");
+
+        verify(repository, never()).save(any(BusinessPartners.class));
+    }
+
+    @Test
+    @DisplayName("should_ApplyTransactionalBoundaries_When_ServiceMethodsInvoked")
+    void should_ApplyTransactionalBoundaries_When_ServiceMethodsInvoked() throws NoSuchMethodException {
+        Method getAllMethod = BusinessPartnerImpl.class.getMethod("getAll");
+        Method createMethod = BusinessPartnerImpl.class.getMethod("create", BusinessPartnerRequest.class);
+
+        Transactional readOnlyTx = getAllMethod.getAnnotation(Transactional.class);
+        Transactional writeTx = createMethod.getAnnotation(Transactional.class);
+
+        assertThat(readOnlyTx).isNotNull();
+        assertThat(readOnlyTx.readOnly()).isTrue();
+        assertThat(writeTx).isNotNull();
+        assertThat(writeTx.readOnly()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Replace raw `RuntimeException` in `BusinessPartnerImpl` with typed domain exceptions
- Map business partner errors to expected 4xx contract:
  - `BP_001` -> `NotFoundException` (404)
  - `BP_002` -> `ConflictException` (409)
  - `BP_003` -> `BadRequestException` (400)
- Add explicit transaction boundaries in service layer:
  - `@Transactional(readOnly = true)` for read methods
  - `@Transactional` for mutating methods

## Files
- `src/main/java/org/demo/whs/service/impl/BusinessPartnerImpl.java`
- `src/test/java/org/demo/whs/service/impl/BusinessPartnerImplTest.java`

## Validation
- Added/updated unit tests for:
  - not found scenario
  - duplicate code scenario
  - invalid status scenario
  - transactional annotation presence