### PR TITLE
[WHS-74] Fix refresh-token rate limit keying for permitAll flow

### DIFF
--- a/src/main/java/org/demo/whs/controller/AuthController.java
+++ b/src/main/java/org/demo/whs/controller/AuthController.java
@@ -74,7 +74,8 @@ public class AuthController {
         limit = 10,
         duration = 60,
         type = RateLimitType.USER,
-        message = "Too many token refresh requests. Please try again later."
+        message = "Too many token refresh requests. Please try again later.",
+        failClosed = true  // Security-sensitive endpoint: block when Redis is unavailable
     )
     public ResponseEntity<BaseResponse<RefreshTokenResponse>> refreshToken(@RequestBody @Valid RefreshTokenRequest request) {
         log.debug("Refresh token request received");

--- a/src/main/java/org/demo/whs/security/CachedBodyHttpServletRequest.java
+++ b/src/main/java/org/demo/whs/security/CachedBodyHttpServletRequest.java
@@ -1,0 +1,68 @@
+package org.demo.whs.security;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.springframework.util.StreamUtils;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * HttpServletRequest wrapper that allows request body to be read multiple times.
+ */
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+    private final byte[] cachedBody;
+
+    public CachedBodyHttpServletRequest(HttpServletRequest request) throws IOException {
+        super(request);
+        this.cachedBody = StreamUtils.copyToByteArray(request.getInputStream());
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        return new CachedBodyServletInputStream(this.cachedBody);
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        Charset charset = getCharacterEncoding() != null
+                ? Charset.forName(getCharacterEncoding())
+                : StandardCharsets.UTF_8;
+        return new BufferedReader(new InputStreamReader(getInputStream(), charset));
+    }
+
+    private static class CachedBodyServletInputStream extends ServletInputStream {
+        private final ByteArrayInputStream inputStream;
+
+        private CachedBodyServletInputStream(byte[] cachedBody) {
+            this.inputStream = new ByteArrayInputStream(cachedBody);
+        }
+
+        @Override
+        public boolean isFinished() {
+            return inputStream.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            // no-op for synchronous request processing
+        }
+
+        @Override
+        public int read() {
+            return inputStream.read();
+        }
+    }
+}

--- a/src/main/java/org/demo/whs/security/RateLimitFilter.java
+++ b/src/main/java/org/demo/whs/security/RateLimitFilter.java
@@ -25,6 +25,9 @@ import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -98,20 +101,21 @@ public class RateLimitFilter extends OncePerRequestFilter {
             @NonNull HttpServletRequest request,
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain) throws ServletException, IOException {
-        
-        String requestURI = request.getRequestURI();
+
+        HttpServletRequest requestToUse = wrapRefreshTokenRequest(request);
+        String requestURI = requestToUse.getRequestURI();
         
         // Skip excluded paths
         if (isExcludedPath(requestURI)) {
-            filterChain.doFilter(request, response);
+            filterChain.doFilter(requestToUse, response);
             return;
         }
         
         try {
             // Lấy handler method để tìm @RateLimit annotation
-            HandlerExecutionChain executionChain = handlerMapping.getHandler(request);
+            HandlerExecutionChain executionChain = handlerMapping.getHandler(requestToUse);
             if (executionChain == null || !(executionChain.getHandler() instanceof HandlerMethod)) {
-                filterChain.doFilter(request, response);
+                filterChain.doFilter(requestToUse, response);
                 return;
             }
             
@@ -125,15 +129,19 @@ public class RateLimitFilter extends OncePerRequestFilter {
             
             // Nếu không có annotation, skip rate limit check
             if (rateLimitAnnotation == null) {
-                filterChain.doFilter(request, response);
+                filterChain.doFilter(requestToUse, response);
                 return;
             }
             
             // Xác định identifier dựa trên RateLimitType
-            String identifier = getIdentifier(request, rateLimitAnnotation.type());
+            String identifier = getIdentifier(
+                requestToUse,
+                rateLimitAnnotation.type(),
+                rateLimitAnnotation.key()
+            );
             
             // Tạo route key = METHOD + best matching pattern
-            String routeKey = buildRouteKey(request, handlerMethod);
+            String routeKey = buildRouteKey(requestToUse, handlerMethod);
             
             log.debug("Rate limit check for endpoint: {}, type: {}, identifier: {}, routeKey: {}", 
                 requestURI, rateLimitAnnotation.type(), identifier, routeKey);
@@ -158,12 +166,12 @@ public class RateLimitFilter extends OncePerRequestFilter {
                 requestURI, rateLimitDTO.getRemaining());
             
             // Allow request to proceed
-            filterChain.doFilter(request, response);
+            filterChain.doFilter(requestToUse, response);
             
         } catch (Exception e) {
             log.error("Error in rate limit filter for URI: {}", requestURI, e);
             // Fail-open: allow request on errors to prevent blocking entire system
-            filterChain.doFilter(request, response);
+            filterChain.doFilter(requestToUse, response);
         }
     }
     
@@ -216,10 +224,10 @@ public class RateLimitFilter extends OncePerRequestFilter {
      * @param type Rate limit type
      * @return Identifier string
      */
-    private String getIdentifier(HttpServletRequest request, RateLimitType type) {
+    private String getIdentifier(HttpServletRequest request, RateLimitType type, String rateLimitKey) {
         return switch (type) {
             case IP -> getTrustedClientIp(request);
-            case USER -> getUserIdentifier();
+            case USER -> getUserIdentifier(request, rateLimitKey);
             case API -> request.getRequestURI();
             case GLOBAL -> "global";
         };
@@ -284,19 +292,103 @@ public class RateLimitFilter extends OncePerRequestFilter {
     /**
      * Lấy user identifier từ SecurityContext
      * 
-     * NOTE: Filter chạy SAU JwtAuthFilter, nên SecurityContext đã có authentication
+     * Nếu SecurityContext đã có authentication thì ưu tiên username.
+     * Nếu chưa có (ví dụ endpoint permitAll như refresh-token), dùng strategy fallback.
      * 
      * @return Username hoặc "anonymous"
      */
-    private String getUserIdentifier() {
+    private String getUserIdentifier(HttpServletRequest request, String rateLimitKey) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         
         if (authentication != null && authentication.isAuthenticated() 
             && !"anonymousUser".equals(authentication.getPrincipal())) {
             return authentication.getName();
         }
-        
+
+        if (isRefreshTokenRequest(request, rateLimitKey)) {
+            return getRefreshTokenStableIdentifier(request);
+        }
+
         return "anonymous";
+    }
+
+    /**
+     * Build a stable rate-limit identifier for refresh-token endpoint
+     * when user authentication context is not available yet.
+     *
+     * Strategy: refresh-ip:{clientIp}:token:{sha256(refreshToken)}
+     */
+    private String getRefreshTokenStableIdentifier(HttpServletRequest request) {
+        String clientIp = getTrustedClientIp(request);
+        String refreshToken = extractRefreshTokenFromBody(request);
+
+        if (refreshToken == null || refreshToken.isBlank()) {
+            return "refresh-ip:" + clientIp;
+        }
+
+        return "refresh-ip:" + clientIp + ":token:" + sha256(refreshToken);
+    }
+
+    private boolean isRefreshTokenRequest(HttpServletRequest request, String rateLimitKey) {
+        if ("refresh-token".equals(rateLimitKey)) {
+            return true;
+        }
+        String requestUri = request.getRequestURI();
+        return requestUri != null && requestUri.endsWith("/api/v1/auth/refresh-token");
+    }
+
+    private HttpServletRequest wrapRefreshTokenRequest(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        if (requestUri == null || !requestUri.endsWith("/api/v1/auth/refresh-token")) {
+            return request;
+        }
+        if (request instanceof CachedBodyHttpServletRequest) {
+            return request;
+        }
+        try {
+            return new CachedBodyHttpServletRequest(request);
+        } catch (IOException ex) {
+            log.warn("Failed to cache refresh-token request body for rate limiting", ex);
+            return request;
+        }
+    }
+
+    private String extractRefreshTokenFromBody(HttpServletRequest request) {
+        try {
+            byte[] requestBodyBytes = request.getInputStream().readAllBytes();
+            if (requestBodyBytes.length == 0) {
+                return null;
+            }
+
+            String requestBody = new String(requestBodyBytes, StandardCharsets.UTF_8);
+            if (requestBody.isBlank()) {
+                return null;
+            }
+
+            String refreshToken = objectMapper.readTree(requestBody).path("refresh_token").asText(null);
+            if (refreshToken == null || refreshToken.isBlank()) {
+                refreshToken = objectMapper.readTree(requestBody).path("refreshToken").asText(null);
+            }
+            return refreshToken;
+        } catch (Exception ex) {
+            log.debug("Cannot extract refresh token from request body for rate-limit key: {}", ex.getMessage());
+            return null;
+        }
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", ex);
+        }
     }
     
     /**

--- a/src/test/java/org/demo/whs/security/RateLimitFilterTest.java
+++ b/src/test/java/org/demo/whs/security/RateLimitFilterTest.java
@@ -1,0 +1,112 @@
+package org.demo.whs.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.demo.whs.entity.dto.RateLimitDTO;
+import org.demo.whs.entity.enums.RateLimitType;
+import org.demo.whs.service.RateLimitService;
+import org.demo.whs.utils.annotation.RateLimit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RateLimitFilter Unit Tests")
+class RateLimitFilterTest {
+
+    @Mock
+    private RateLimitService rateLimitService;
+
+    @Mock
+    private RequestMappingHandlerMapping handlerMapping;
+
+    private RateLimitFilter rateLimitFilter;
+    private HandlerExecutionChain refreshTokenExecutionChain;
+
+    @BeforeEach
+    void setUp() throws NoSuchMethodException {
+        rateLimitFilter = new RateLimitFilter(rateLimitService, handlerMapping, new ObjectMapper());
+        HandlerMethod refreshHandlerMethod = new HandlerMethod(
+                new TestAuthController(),
+                TestAuthController.class.getMethod("refreshToken")
+        );
+        refreshTokenExecutionChain = new HandlerExecutionChain(refreshHandlerMethod);
+    }
+
+    @Test
+    @DisplayName("should_UseDifferentBucketKeys_When_RefreshTokensAreDifferent")
+    void should_UseDifferentBucketKeys_When_RefreshTokensAreDifferent() throws Exception {
+        when(handlerMapping.getHandler(any())).thenReturn(refreshTokenExecutionChain);
+        when(rateLimitService.checkRateLimit(any(), anyString(), anyString()))
+                .thenReturn(new RateLimitDTO(true, 9, 10, System.currentTimeMillis() / 1000 + 60, null));
+
+        MockHttpServletRequest request1 = buildRefreshTokenRequest("203.0.113.10", "refresh-token-user-1");
+        MockHttpServletRequest request2 = buildRefreshTokenRequest("203.0.113.10", "refresh-token-user-2");
+
+        rateLimitFilter.doFilter(request1, new MockHttpServletResponse(), new MockFilterChain());
+        rateLimitFilter.doFilter(request2, new MockHttpServletResponse(), new MockFilterChain());
+
+        ArgumentCaptor<String> identifierCaptor = ArgumentCaptor.forClass(String.class);
+        verify(rateLimitService, times(2)).checkRateLimit(any(), identifierCaptor.capture(), anyString());
+
+        List<String> identifiers = identifierCaptor.getAllValues();
+        assertThat(identifiers).hasSize(2);
+        assertThat(identifiers.get(0)).isNotEqualTo(identifiers.get(1));
+        assertThat(identifiers.get(0)).startsWith("refresh-ip:203.0.113.10:token:");
+        assertThat(identifiers.get(1)).startsWith("refresh-ip:203.0.113.10:token:");
+    }
+
+    @Test
+    @DisplayName("should_UseIpFallbackKey_When_RefreshTokenIsMissing")
+    void should_UseIpFallbackKey_When_RefreshTokenIsMissing() throws Exception {
+        when(handlerMapping.getHandler(any())).thenReturn(refreshTokenExecutionChain);
+        when(rateLimitService.checkRateLimit(any(), anyString(), anyString()))
+                .thenReturn(new RateLimitDTO(true, 9, 10, System.currentTimeMillis() / 1000 + 60, null));
+
+        MockHttpServletRequest request = buildRefreshTokenRequest("203.0.113.20", "");
+        request.setContent("{}".getBytes(StandardCharsets.UTF_8));
+
+        rateLimitFilter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        ArgumentCaptor<String> identifierCaptor = ArgumentCaptor.forClass(String.class);
+        verify(rateLimitService).checkRateLimit(any(), identifierCaptor.capture(), anyString());
+        assertThat(identifierCaptor.getValue()).isEqualTo("refresh-ip:203.0.113.20");
+    }
+
+    private MockHttpServletRequest buildRefreshTokenRequest(String remoteIp, String refreshToken) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/refresh-token");
+        request.setRemoteAddr(remoteIp);
+        request.setContentType("application/json");
+        String body = "{\"refresh_token\":\"" + refreshToken + "\"}";
+        request.setContent(body.getBytes(StandardCharsets.UTF_8));
+        return request;
+    }
+
+    private static class TestAuthController {
+        @RateLimit(
+                key = "refresh-token",
+                limit = 10,
+                duration = 60,
+                type = RateLimitType.USER
+        )
+        public void refreshToken() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix rate-limit keying for `/api/v1/auth/refresh-token` where USER-based limiting could collapse to shared `anonymous` bucket
- Implement stable identifier strategy for refresh flow without authenticated context:
  - `refresh-ip:{clientIp}:token:{sha256(refresh_token)}`
- Add request-body caching wrapper so filter can safely read refresh token without breaking controller body consumption
- Make fail-mode explicit for refresh-token endpoint with `failClosed = true`

## Files
- `src/main/java/org/demo/whs/controller/AuthController.java`
- `src/main/java/org/demo/whs/security/RateLimitFilter.java`
- `src/main/java/org/demo/whs/security/CachedBodyHttpServletRequest.java`
- `src/test/java/org/demo/whs/security/RateLimitFilterTest.java`

## Validation
- Added unit tests proving:
  - different refresh tokens map to different limiter keys
  - missing refresh token falls back to IP-based refresh key