### PR TITLE
[WHS-72] Fix inventory validation errors to return domain 400 responses

### DIFF
--- a/src/main/java/org/demo/whs/controller/InventoryController.java
+++ b/src/main/java/org/demo/whs/controller/InventoryController.java
@@ -1,13 +1,13 @@
 package org.demo.whs.controller;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.dto.request.Inventory.InventoryFilterRequest;
 import org.demo.whs.entity.dto.response.BaseResponse;
 import org.demo.whs.entity.dto.response.Inventory.InventoryResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.service.InventoryService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -58,8 +58,8 @@ public class InventoryController {
             @RequestParam(required = false) String locationId,
             @RequestParam(required = false) String batchId,
             @RequestParam(required = false) String batchNumber,
-            @RequestParam(defaultValue = "0") @Min(0) Integer page,
-            @RequestParam(defaultValue = "10") @Min(1) @Max(100) Integer size,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size,
             @RequestParam(defaultValue = "updatedAt") String sortBy,
             @RequestParam(defaultValue = "DESC") Sort.Direction direction){
 
@@ -70,7 +70,19 @@ public class InventoryController {
         );
 
         if (!allowedSortFields.contains(sortBy)) {
-            throw new IllegalArgumentException("COM_001 - Invalid sort field");
+            throw new BadRequestException(ErrorCode.COM_001);
+        }
+
+        if (page < 0) {
+            throw new BadRequestException(ErrorCode.COM_006);
+        }
+
+        if (size <= 0) {
+            throw new BadRequestException(ErrorCode.COM_007);
+        }
+
+        if (size > 100) {
+            throw new BadRequestException(ErrorCode.COM_008);
         }
 
         InventoryFilterRequest filter = InventoryFilterRequest.builder()

--- a/src/main/java/org/demo/whs/service/impl/InventoryServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/InventoryServiceImpl.java
@@ -6,6 +6,7 @@ import org.demo.whs.entity.*;
 import org.demo.whs.entity.dto.request.Inventory.InventoryFilterRequest;
 import org.demo.whs.entity.dto.response.Inventory.InventoryResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.exception.BadRequestException;
 import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.mapper.InventoryMapper;
 import org.demo.whs.repository.*;
@@ -78,13 +79,13 @@ public class InventoryServiceImpl implements InventoryService {
 
     private void validatePageable(Pageable pageable) {
         if (pageable.getPageNumber() < 0) {
-            throw new IllegalArgumentException(ErrorCode.COM_006.getMessage());
+            throw new BadRequestException(ErrorCode.COM_006);
         }
         if (pageable.getPageSize() <= 0) {
-            throw new IllegalArgumentException(ErrorCode.COM_007.getMessage());
+            throw new BadRequestException(ErrorCode.COM_007);
         }
         if (pageable.getPageSize() > 100) {
-            throw new IllegalArgumentException(ErrorCode.COM_008.getMessage());
+            throw new BadRequestException(ErrorCode.COM_008);
         }
     }
 }

--- a/src/test/java/org/demo/whs/controller/InventoryControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/InventoryControllerTest.java
@@ -1,7 +1,5 @@
 package org.demo.whs.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.demo.whs.entity.dto.response.BaseResponse;
 import org.demo.whs.entity.dto.response.Inventory.InventoryResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.service.InventoryService;
@@ -24,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(InventoryController.class)
+@WithMockUser
 class InventoryControllerTest {
 
     @Autowired
@@ -35,11 +34,7 @@ class InventoryControllerTest {
     @MockBean
     private RateLimitService rateLimitService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     @Test
-    @WithMockUser
     @DisplayName("Should return 200 when request is valid")
     void shouldReturn200WhenValidRequest() throws Exception {
 
@@ -77,7 +72,8 @@ class InventoryControllerTest {
         mockMvc.perform(get("/api/v1/inventories")
                         .param("sortBy", "abcxyz")
                         .param("direction", "ASC"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
     }
 
     @Test
@@ -87,7 +83,8 @@ class InventoryControllerTest {
         mockMvc.perform(get("/api/v1/inventories")
                         .param("sortBy", "updatedAt")
                         .param("direction", "HELLO"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
     }
 
     @Test
@@ -97,7 +94,18 @@ class InventoryControllerTest {
         mockMvc.perform(get("/api/v1/inventories")
                         .param("page", "-1")
                         .param("size", "10"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("COM_006"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 when size is zero")
+    void shouldReturn400WhenSizeIsZero() throws Exception {
+
+        mockMvc.perform(get("/api/v1/inventories")
+                        .param("size", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("COM_007"));
     }
 
     @Test
@@ -106,6 +114,7 @@ class InventoryControllerTest {
 
         mockMvc.perform(get("/api/v1/inventories")
                         .param("size", "101"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("COM_008"));
     }
 }

--- a/src/test/java/org/demo/whs/service/impl/InventoryServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/InventoryServiceImplTest.java
@@ -1,0 +1,82 @@
+package org.demo.whs.service.impl;
+
+import org.demo.whs.entity.dto.request.Inventory.InventoryFilterRequest;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.repository.BatchRepository;
+import org.demo.whs.repository.InventoryRepository;
+import org.demo.whs.repository.LocationRepository;
+import org.demo.whs.repository.ProductRepository;
+import org.demo.whs.repository.WareHouseRepository;
+import org.demo.whs.mapper.InventoryMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InventoryServiceImpl Unit Tests")
+class InventoryServiceImplTest {
+
+    @Mock
+    private InventoryRepository inventoryRepository;
+
+    @Mock
+    private InventoryMapper inventoryMapper;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private WareHouseRepository wareHouseRepository;
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @Mock
+    private BatchRepository batchRepository;
+
+    @InjectMocks
+    private InventoryServiceImpl inventoryService;
+
+    @Test
+    @DisplayName("should_ThrowBadRequest_When_PageNumberIsNegative")
+    void should_ThrowBadRequest_When_PageNumberIsNegative() {
+        Pageable pageable = mock(Pageable.class);
+        when(pageable.getPageNumber()).thenReturn(-1);
+
+        assertThatThrownBy(() -> inventoryService.getInventories(InventoryFilterRequest.builder().build(), pageable))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "COM_006");
+    }
+
+    @Test
+    @DisplayName("should_ThrowBadRequest_When_PageSizeIsZero")
+    void should_ThrowBadRequest_When_PageSizeIsZero() {
+        Pageable pageable = mock(Pageable.class);
+        when(pageable.getPageNumber()).thenReturn(0);
+        when(pageable.getPageSize()).thenReturn(0);
+
+        assertThatThrownBy(() -> inventoryService.getInventories(InventoryFilterRequest.builder().build(), pageable))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "COM_007");
+    }
+
+    @Test
+    @DisplayName("should_ThrowBadRequest_When_PageSizeExceedsLimit")
+    void should_ThrowBadRequest_When_PageSizeExceedsLimit() {
+        Pageable pageable = mock(Pageable.class);
+        when(pageable.getPageNumber()).thenReturn(0);
+        when(pageable.getPageSize()).thenReturn(101);
+
+        assertThatThrownBy(() -> inventoryService.getInventories(InventoryFilterRequest.builder().build(), pageable))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", "COM_008");
+    }
+}


### PR DESCRIPTION
## Summary
- Replace inventory query validation failures that could surface as generic errors with domain `BadRequestException`
- Ensure `/api/v1/inventories` returns 400 with consistent error codes for invalid query inputs:
  - `COM_001` for invalid sort field
  - `COM_006` for negative page
  - `COM_007` for non-positive page size
  - `COM_008` for oversized page size
- Keep defensive pageable validation in service layer using domain exceptions

## Files
- `src/main/java/org/demo/whs/controller/InventoryController.java`
- `src/main/java/org/demo/whs/service/impl/InventoryServiceImpl.java`
- `src/test/java/org/demo/whs/controller/InventoryControllerTest.java`
- `src/test/java/org/demo/whs/service/impl/InventoryServiceImplTest.java`

## Validation
- Added/updated tests for invalid sort field, negative page, zero/oversized page size
- Command used:
  - `./mvnw test -DskipITs "-Dtest=org.demo.whs.controller.InventoryControllerTest,org.demo.whs.service.impl.InventoryServiceImplTest"`