### PR TITLE
[WHS-73] Fix email controller admin authorization consistency

### DIFF
--- a/src/main/java/org/demo/whs/controller/EmailController.java
+++ b/src/main/java/org/demo/whs/controller/EmailController.java
@@ -64,7 +64,7 @@ public class EmailController {
      * GET /api/v1/emails/{id}
      */
     @GetMapping("/{id}")
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get email log", description = "Get email log details by ID")
     public ResponseEntity<EmailLogResponse> getEmailLog(@PathVariable String id) {
         log.info("Fetching email log with ID: {}", id);
@@ -78,7 +78,7 @@ public class EmailController {
      * GET /api/v1/emails
      */
     @GetMapping
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get all email logs", description = "Get all email logs with pagination")
     public ResponseEntity<Page<EmailLogResponse>> getAllEmailLogs(
             @RequestParam(defaultValue = "0") int page,
@@ -102,7 +102,7 @@ public class EmailController {
      * GET /api/v1/emails/status/{status}
      */
     @GetMapping("/status/{status}")
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get emails by status", description = "Get email logs filtered by status")
     public ResponseEntity<Page<EmailLogResponse>> getEmailLogsByStatus(
             @PathVariable EmailStatus status,
@@ -121,7 +121,7 @@ public class EmailController {
      * GET /api/v1/emails/type/{type}
      */
     @GetMapping("/type/{type}")
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get emails by type", description = "Get email logs filtered by email type")
     public ResponseEntity<Page<EmailLogResponse>> getEmailLogsByType(
             @PathVariable EmailType type,
@@ -140,7 +140,7 @@ public class EmailController {
      * GET /api/v1/emails/recipient/{email}
      */
     @GetMapping("/recipient/{email}")
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get emails by recipient", description = "Get email logs for specific recipient")
     public ResponseEntity<Page<EmailLogResponse>> getEmailLogsByRecipient(
             @PathVariable String email,
@@ -159,6 +159,7 @@ public class EmailController {
      * POST /api/v1/emails/{id}/retry
      */
     @PostMapping("/{id}/retry")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<EmailLogResponse> retryEmail(@PathVariable String id) {
         log.info("Retrying email with ID: {}", id);
         EmailLog retried = emailService.retryEmail(id);
@@ -173,7 +174,7 @@ public class EmailController {
      * GET /api/v1/emails/statistics
      */
     @GetMapping("/statistics")
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get email statistics", description = "Get statistics about email sending")
     public ResponseEntity<Map<String, Long>> getEmailStatistics() {
         log.info("Fetching email statistics");
@@ -187,7 +188,7 @@ public class EmailController {
      * POST /api/v1/emails/process-pending
      */
     @PostMapping("/process-pending")
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Process pending emails", description = "Manually trigger processing of pending emails")
     public ResponseEntity<String> processPendingEmails() {
         log.info("Manually triggering pending email processing");
@@ -201,7 +202,7 @@ public class EmailController {
      * POST /api/v1/emails/retry-failed
      */
     @PostMapping("/retry-failed")
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Retry failed emails", description = "Manually trigger retry of failed emails")
     public ResponseEntity<String> retryFailedEmails() {
         log.info("Manually triggering failed email retry");

--- a/src/test/java/org/demo/whs/controller/EmailControllerSecurityTest.java
+++ b/src/test/java/org/demo/whs/controller/EmailControllerSecurityTest.java
@@ -1,0 +1,151 @@
+package org.demo.whs.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.demo.whs.entity.EmailLog;
+import org.demo.whs.entity.dto.request.SendEmailRequest;
+import org.demo.whs.entity.dto.response.EmailLogResponse;
+import org.demo.whs.entity.enums.EmailStatus;
+import org.demo.whs.entity.enums.EmailType;
+import org.demo.whs.exception.GlobalExceptionHandle;
+import org.demo.whs.service.EmailService;
+import org.demo.whs.service.RateLimitService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EmailController.class)
+@ActiveProfiles("test")
+@Import({EmailControllerSecurityTest.TestSecurityConfig.class, GlobalExceptionHandle.class})
+class EmailControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private EmailService emailService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @BeforeEach
+    void setUp() {
+        EmailLog emailLog = new EmailLog();
+        emailLog.setId("email-1");
+
+        EmailLogResponse response = EmailLogResponse.builder()
+                .id("email-1")
+                .recipient("admin@example.com")
+                .subject("Subject")
+                .emailType(EmailType.NOTIFICATION)
+                .status(EmailStatus.SENT)
+                .retryCount(0)
+                .hasAttachment(false)
+                .priority(5)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .triggeredByUsername("admin")
+                .build();
+
+        when(emailService.sendEmail(any(SendEmailRequest.class))).thenReturn(emailLog);
+        when(emailService.sendEmailAsync(any(SendEmailRequest.class))).thenReturn(emailLog);
+        when(emailService.getEmailLog(anyString())).thenReturn(response);
+        when(emailService.getAllEmailLogs(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(response)));
+        when(emailService.getEmailLogsByStatus(any(EmailStatus.class), any(Pageable.class))).thenReturn(new PageImpl<>(List.of(response)));
+        when(emailService.getEmailLogsByType(any(EmailType.class), any(Pageable.class))).thenReturn(new PageImpl<>(List.of(response)));
+        when(emailService.getEmailLogsByRecipient(anyString(), any(Pageable.class))).thenReturn(new PageImpl<>(List.of(response)));
+        when(emailService.retryEmail(anyString())).thenReturn(emailLog);
+        when(emailService.getEmailStatistics()).thenReturn(Map.of("total", 1L));
+        doNothing().when(emailService).processPendingEmails();
+        doNothing().when(emailService).retryFailedEmails();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Should allow admin role on all email endpoints")
+    void should_AllowAdminRole_OnAllEmailEndpoints() throws Exception {
+        for (MockHttpServletRequestBuilder request : buildAllEndpointRequests()) {
+            mockMvc.perform(request)
+                    .andExpect(status().is2xxSuccessful());
+        }
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("Should forbid non-admin role on all email endpoints")
+    void should_ForbidNonAdminRole_OnAllEmailEndpoints() throws Exception {
+        for (MockHttpServletRequestBuilder request : buildAllEndpointRequests()) {
+            mockMvc.perform(request)
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    private List<MockHttpServletRequestBuilder> buildAllEndpointRequests() throws Exception {
+        SendEmailRequest sendEmailRequest = SendEmailRequest.builder()
+                .recipient("admin@example.com")
+                .subject("Subject")
+                .content("<p>content</p>")
+                .emailType(EmailType.NOTIFICATION)
+                .priority(5)
+                .async(false)
+                .build();
+
+        return List.of(
+                post("/api/v1/emails/send")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(sendEmailRequest)),
+                get("/api/v1/emails/{id}", "email-1"),
+                get("/api/v1/emails"),
+                get("/api/v1/emails/status/{status}", EmailStatus.SENT),
+                get("/api/v1/emails/type/{type}", EmailType.NOTIFICATION),
+                get("/api/v1/emails/recipient/{email}", "admin@example.com"),
+                post("/api/v1/emails/{id}/retry", "email-1"),
+                get("/api/v1/emails/statistics"),
+                post("/api/v1/emails/process-pending"),
+                post("/api/v1/emails/retry-failed")
+        );
+    }
+
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                    .formLogin(AbstractHttpConfigurer::disable)
+                    .httpBasic(AbstractHttpConfigurer::disable);
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Standardize email endpoint authorization to a single admin check strategy using `hasRole('ADMIN')`
- Protect `POST /api/v1/emails/{id}/retry` with explicit admin authorization
- Remove mixed `hasAuthority('ADMIN')` usage that could mismatch with actual `ROLE_ADMIN` authorities

## Files
- `src/main/java/org/demo/whs/controller/EmailController.java`
- `src/test/java/org/demo/whs/controller/EmailControllerSecurityTest.java`

## Validation
- Added security-focused controller test coverage for all email endpoints:
  - admin role is allowed
  - non-admin role is forbidden
- Command used:
  - `./mvnw test -DskipITs "-Dtest=org.demo.whs.controller.EmailControllerSecurityTest"`