### PR TITLE
fix(WHS-79): make AUTH_010 error code unique

### DIFF
--- a/src/main/java/org/demo/whs/exception/ErrorCode.java
+++ b/src/main/java/org/demo/whs/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     AUTH_007("AUTH_007", "Account is locked due to suspicious activity"),
     AUTH_008("AUTH_008", "Too many failed login attempts - please try again later"),
     AUTH_009("AUTH_009", "Account is not active"),
-    AUTH_010("AUTH_009", "Account is not found"),
+    AUTH_010("AUTH_010", "Account is not found"),
 
     // Password reset errors
     RESET_001("RESET_001", "Invalid or expired reset token"),

--- a/src/test/java/org/demo/whs/exception/ErrorCodeTest.java
+++ b/src/test/java/org/demo/whs/exception/ErrorCodeTest.java
@@ -1,0 +1,30 @@
+package org.demo.whs.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ErrorCode enum tests")
+class ErrorCodeTest {
+
+    @Test
+    @DisplayName("All error code values should be unique")
+    void should_HaveUniqueCodeValues_When_EnumeratingAllErrorCodes() {
+        Set<String> uniqueCodes = Arrays.stream(ErrorCode.values())
+                .map(ErrorCode::getCode)
+                .collect(Collectors.toSet());
+
+        assertThat(uniqueCodes).hasSameSizeAs(ErrorCode.values());
+    }
+
+    @Test
+    @DisplayName("AUTH_010 should map to AUTH_010 value")
+    void should_MapAuth010ToUniqueValue_When_ReadingAuth010() {
+        assertThat(ErrorCode.AUTH_010.getCode()).isEqualTo("AUTH_010");
+    }
+}


### PR DESCRIPTION
## Summary
- fix duplicated auth error code mapping by setting `AUTH_010` to `AUTH_010`
- add `ErrorCodeTest` to assert all enum code values are unique
- add regression assertion for `AUTH_010`

## Jira
- WHS-79

## Testing
- `./mvnw test -DskipITs "-Dtest=org.demo.whs.exception.ErrorCodeTest"`