### PR TITLE
fix(WHS-80): remove deprecated rate-limit interceptor from runtime bean context

### DIFF
--- a/src/main/java/org/demo/whs/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/org/demo/whs/interceptor/RateLimitInterceptor.java
@@ -12,7 +12,6 @@ import org.demo.whs.security.RateLimitFilter;
 import org.demo.whs.service.RateLimitService;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -32,7 +31,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
  */
 @Deprecated(since = "2.0", forRemoval = true)
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class RateLimitInterceptor implements HandlerInterceptor {
     

--- a/src/test/java/org/demo/whs/controller/EmployeeControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/EmployeeControllerTest.java
@@ -8,6 +8,7 @@ import org.demo.whs.exception.GlobalExceptionHandle;
 import org.demo.whs.exception.NotFoundException;
 import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.service.EmployeeService;
+import org.demo.whs.service.RateLimitService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +52,9 @@ class EmployeeControllerTest {
 
     @MockitoBean
     private EmployeeService employeeService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
 
     @Test
     @DisplayName("Get employee by id success -> 200 OK")

--- a/src/test/java/org/demo/whs/interceptor/RateLimitInterceptorRegistrationTest.java
+++ b/src/test/java/org/demo/whs/interceptor/RateLimitInterceptorRegistrationTest.java
@@ -1,0 +1,17 @@
+package org.demo.whs.interceptor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("RateLimitInterceptor registration tests")
+class RateLimitInterceptorRegistrationTest {
+
+    @Test
+    @DisplayName("Deprecated interceptor should not be a Spring component")
+    void should_NotBeSpringComponent_When_FilterIsSourceOfTruth() {
+        assertThat(RateLimitInterceptor.class.isAnnotationPresent(Component.class)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- remove Spring component registration from deprecated `RateLimitInterceptor`
- keep filter-based rate limiting as the only runtime path
- add registration guard test to ensure interceptor is not auto-registered
- update `EmployeeControllerTest` with `RateLimitService` mock bean so WebMvc slice context loads with filter-only infra

## Jira
- WHS-80

## Testing
- `./mvnw test -DskipITs "-Dtest=org.demo.whs.interceptor.RateLimitInterceptorRegistrationTest,org.demo.whs.controller.EmployeeControllerTest"`