### PR TITLE
fix(WHS-75): harden storage upload validation and null safety

### DIFF
--- a/src/main/java/org/demo/whs/controller/StorageController.java
+++ b/src/main/java/org/demo/whs/controller/StorageController.java
@@ -60,8 +60,9 @@ public class StorageController {
             @Parameter(description = "Logical folder prefix, e.g. 'products' or 'inbound/receipts'")
             @RequestParam(value = "folder", defaultValue = "uploads") String folder) {
 
+        String originalFilename = file == null ? null : file.getOriginalFilename();
         log.info("POST /api/v1/storage/upload – file='{}', folder='{}'",
-                file.getOriginalFilename(), folder);
+                originalFilename, folder);
 
         FileUploadResponse response = storageService.uploadFile(file, folder);
         return ResponseEntity.ok(BaseResponse.success(response, "File uploaded successfully"));
@@ -81,17 +82,18 @@ public class StorageController {
             @RequestParam("files") List<MultipartFile> files,
             @RequestParam(value = "folder", defaultValue = "uploads") String folder) {
 
+        int fileCount = files == null ? 0 : files.size();
         log.info("POST /api/v1/storage/upload/batch – count={}, folder='{}'",
-                files.size(), folder);
+                fileCount, folder);
 
-        if (files.size() > 10) {
+        if (fileCount > 10) {
             return ResponseEntity.badRequest()
                     .body(BaseResponse.error("COM_003", "Maximum 10 files per batch upload", null));
         }
 
         List<FileUploadResponse> responses = storageService.uploadFiles(files, folder);
         return ResponseEntity.ok(
-                BaseResponse.success(responses, files.size() + " file(s) uploaded successfully"));
+                BaseResponse.success(responses, fileCount + " file(s) uploaded successfully"));
     }
 
     // =========================================================================

--- a/src/main/java/org/demo/whs/service/impl/StorageServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/StorageServiceImpl.java
@@ -60,7 +60,7 @@ public class StorageServiceImpl implements StorageService {
      */
     private void validateFile(MultipartFile file) {
         if (file == null || file.isEmpty()) {
-            throw new StorageException(ErrorCode.STORAGE_001);
+            throw new StorageException(ErrorCode.STORAGE_001, HttpStatus.BAD_REQUEST);
         }
 
         String contentType = file.getContentType();
@@ -114,10 +114,11 @@ public class StorageServiceImpl implements StorageService {
      */
     @Override
     public FileUploadResponse uploadFile(MultipartFile file, String folder) {
-        log.info("Uploading file: {} to folder: {}", file.getOriginalFilename(), folder);
+        String originalFilename = file == null ? null : file.getOriginalFilename();
+        log.info("Uploading file: {} to folder: {}", originalFilename, folder);
         validateFile(file);
 
-        String objectName = buildObjectName(folder, file.getOriginalFilename());
+        String objectName = buildObjectName(folder, originalFilename);
         try (InputStream inputStream = file.getInputStream()) {
 
             // Upload the file to MinIO
@@ -138,7 +139,7 @@ public class StorageServiceImpl implements StorageService {
             return FileMapper.toResponse(objectName, file, presignedUrl, expiresAt);
 
         } catch (Exception e) {
-            log.error("Failed to upload file: {} to MinIO", file.getOriginalFilename(), e);
+            log.error("Failed to upload file: {} to MinIO", originalFilename, e);
             throw new StorageException(ErrorCode.STORAGE_001);
         }
     }
@@ -153,7 +154,11 @@ public class StorageServiceImpl implements StorageService {
     @Override
     public List<FileUploadResponse> uploadFiles(List<MultipartFile> files, String folder) {
         if (files == null || files.isEmpty()) {
-            throw new StorageException(ErrorCode.STORAGE_001);
+            throw new StorageException(ErrorCode.STORAGE_001, HttpStatus.BAD_REQUEST);
+        }
+
+        if (files.stream().anyMatch(Objects::isNull)) {
+            throw new StorageException(ErrorCode.STORAGE_001, HttpStatus.BAD_REQUEST);
         }
 
         return files.stream()

--- a/src/test/java/org/demo/whs/service/StorageServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/StorageServiceImplTest.java
@@ -12,9 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -36,8 +38,8 @@ class StorageServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        when(minioProperties.getBucketName()).thenReturn("whs-storage");
-        when(minioProperties.getPresignedUrlExpiry()).thenReturn(3600);
+        lenient().when(minioProperties.getBucketName()).thenReturn("whs-storage");
+        lenient().when(minioProperties.getPresignedUrlExpiry()).thenReturn(3600);
     }
 
     // =========================================================================
@@ -96,6 +98,7 @@ class StorageServiceImplTest {
 
         assertThatThrownBy(() -> storageService.uploadFile(file, "uploads"))
                 .isInstanceOf(StorageException.class)
+                .hasFieldOrPropertyWithValue("status", HttpStatus.UNSUPPORTED_MEDIA_TYPE)
                 .hasMessageContaining("File type not allowed");
     }
 
@@ -113,7 +116,8 @@ class StorageServiceImplTest {
     @DisplayName("uploadFile – null file – throws StorageException")
     void uploadFile_nullFile_throwsStorageException() {
         assertThatThrownBy(() -> storageService.uploadFile(null, "uploads"))
-                .isInstanceOf(StorageException.class);
+                .isInstanceOf(StorageException.class)
+                .hasFieldOrPropertyWithValue("status", HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -125,6 +129,7 @@ class StorageServiceImplTest {
 
         assertThatThrownBy(() -> storageService.uploadFile(file, "uploads"))
                 .isInstanceOf(StorageException.class)
+                .hasFieldOrPropertyWithValue("status", HttpStatus.PAYLOAD_TOO_LARGE)
                 .hasMessageContaining("File size exceeds maximum allowed limit");
     }
 
@@ -168,17 +173,30 @@ class StorageServiceImplTest {
     }
 
     @Test
-    @DisplayName("uploadFiles – empty list – returns empty list")
-    void uploadFiles_emptyList_returnsEmptyList() {
-        List<FileUploadResponse> responses = storageService.uploadFiles(List.of(), "gallery");
-        assertThat(responses).isEmpty();
+    @DisplayName("uploadFiles – empty list – throws StorageException with 400")
+    void uploadFiles_emptyList_throwsStorageException() {
+        assertThatThrownBy(() -> storageService.uploadFiles(List.of(), "gallery"))
+                .isInstanceOf(StorageException.class)
+                .hasFieldOrPropertyWithValue("status", HttpStatus.BAD_REQUEST);
     }
 
     @Test
-    @DisplayName("uploadFiles – null list – returns empty list")
-    void uploadFiles_nullList_returnsEmptyList() {
-        List<FileUploadResponse> responses = storageService.uploadFiles(null, "gallery");
-        assertThat(responses).isEmpty();
+    @DisplayName("uploadFiles – null list – throws StorageException with 400")
+    void uploadFiles_nullList_throwsStorageException() {
+        assertThatThrownBy(() -> storageService.uploadFiles(null, "gallery"))
+                .isInstanceOf(StorageException.class)
+                .hasFieldOrPropertyWithValue("status", HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("uploadFiles – list contains null file – throws StorageException with 400")
+    void uploadFiles_listContainsNull_throwsStorageException() {
+        MockMultipartFile validFile = new MockMultipartFile(
+                "files", "img1.jpg", "image/jpeg", "bytes1".getBytes());
+
+        assertThatThrownBy(() -> storageService.uploadFiles(Arrays.asList(validFile, null), "gallery"))
+                .isInstanceOf(StorageException.class)
+                .hasFieldOrPropertyWithValue("status", HttpStatus.BAD_REQUEST);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- prevent null-pointer risk in storage upload logging by using null-safe filename handling
- map validation-like storage errors to client 4xx contract (`400`, `415`, `413`)
- make batch upload null/empty/null-element handling deterministic with `400`
- align controller logging/count handling to avoid null list crashes
- update and extend storage service unit tests for null/empty/unsupported/oversize scenarios

## Jira
- WHS-75

## Testing
- `./mvnw test -DskipITs "-Dtest=org.demo.whs.service.StorageServiceImplTest"`