### PR TITLE
fix(WHS-76): support deleting storage objects with nested folder paths

### DIFF
--- a/src/main/java/org/demo/whs/controller/StorageController.java
+++ b/src/main/java/org/demo/whs/controller/StorageController.java
@@ -122,19 +122,47 @@ public class StorageController {
     // =========================================================================
 
     /**
-     * Delete a stored object.  Requires ADMIN or MANAGER role.
+     * Delete a stored object by query param.
+     * Recommended for object names that contain nested path segments.
      *
-     * @param objectName URL-encoded full object path
+     * Example:
+     * DELETE /api/v1/storage?objectName=products/2026/03/file.png
+     *
+     * @param objectName full object path
      */
     @Operation(summary = "Delete a file from MinIO storage")
-    @DeleteMapping("/{objectName}")
+    @DeleteMapping(params = "objectName")
     @PreAuthorize("hasAnyRole('ADMIN','MANAGER')")
     public ResponseEntity<BaseResponse<Void>> deleteFile(
-            @PathVariable String objectName) {
+            @NotBlank(message = "objectName must not be blank")
+            @RequestParam("objectName") String objectName) {
 
-        log.info("DELETE /api/v1/storage/{}", objectName);
+        log.info("DELETE /api/v1/storage?objectName={}", objectName);
 
         storageService.deleteFile(objectName);
+        return ResponseEntity.ok(BaseResponse.success(null, "File deleted successfully"));
+    }
+
+    /**
+     * Backward-compatible delete endpoint using path segment wildcard.
+     *
+     * Example:
+     * DELETE /api/v1/storage/products/2026/03/file.png
+     *
+     * @param objectName full object path captured from wildcard path variable
+     */
+    @DeleteMapping("/{*objectName}")
+    @PreAuthorize("hasAnyRole('ADMIN','MANAGER')")
+    public ResponseEntity<BaseResponse<Void>> deleteFileLegacyPath(
+            @PathVariable String objectName) {
+
+        String normalizedObjectName = objectName.startsWith("/")
+                ? objectName.substring(1)
+                : objectName;
+
+        log.info("DELETE /api/v1/storage/{}", normalizedObjectName);
+
+        storageService.deleteFile(normalizedObjectName);
         return ResponseEntity.ok(BaseResponse.success(null, "File deleted successfully"));
     }
 

--- a/src/test/java/org/demo/whs/controller/StorageControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/StorageControllerTest.java
@@ -1,0 +1,70 @@
+package org.demo.whs.controller;
+
+import org.demo.whs.exception.GlobalExceptionHandle;
+import org.demo.whs.service.RateLimitService;
+import org.demo.whs.service.StorageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StorageController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import(GlobalExceptionHandle.class)
+@ImportAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        FlywayAutoConfiguration.class
+})
+class StorageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StorageService storageService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @Test
+    @DisplayName("Delete file by query param with nested object path should return 200")
+    void should_DeleteFileByQueryParam_When_ObjectNameContainsFolders() throws Exception {
+        String objectName = "products/2026/03/file.png";
+        doNothing().when(storageService).deleteFile(objectName);
+
+        mockMvc.perform(delete("/api/v1/storage")
+                        .param("objectName", objectName))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(storageService).deleteFile(objectName);
+    }
+
+    @Test
+    @DisplayName("Delete file by legacy path wildcard with nested object path should return 200")
+    void should_DeleteFileByLegacyPath_When_ObjectNameContainsFolders() throws Exception {
+        String objectName = "products/2026/03/file.png";
+        doNothing().when(storageService).deleteFile(objectName);
+
+        mockMvc.perform(delete("/api/v1/storage/products/2026/03/file.png"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(storageService).deleteFile(objectName);
+    }
+}


### PR DESCRIPTION
## Summary
- update delete API to support full object names that contain folder separators
- add query-param delete endpoint (`DELETE /api/v1/storage?objectName=...`) as recommended contract
- keep backward-compatible wildcard path endpoint for legacy calls
- normalize wildcard path object name before delegating to service
- add MVC tests for both query-param and nested-path deletion flows

## Jira
- WHS-76

## Testing
- `./mvnw test -DskipITs "-Dtest=org.demo.whs.controller.StorageControllerTest"`