### PR TITLE
fix(WHS-77): block UOM delete when still referenced by products

### DIFF
--- a/src/main/java/org/demo/whs/exception/ErrorCode.java
+++ b/src/main/java/org/demo/whs/exception/ErrorCode.java
@@ -74,6 +74,7 @@ public enum ErrorCode {
     UOM_001("UOM_001", "Unit of Measure not found"),
     UOM_002("UOM_002", "Unit of Measure code already exists"),
     UOM_003("UOM_003", "Data is not null"),
+    UOM_004("UOM_004", "Unit of Measure is in use by products"),
 
     // Employee errors
     EMP_001("EMP_001", "Employee not found"),

--- a/src/main/java/org/demo/whs/service/impl/UnitsOfMeasureImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/UnitsOfMeasureImpl.java
@@ -10,6 +10,7 @@ import org.demo.whs.entity.dto.response.UnitsOfMeasure.UnitsOfMeasureResponse;
 import org.demo.whs.exception.BadRequestException;
 import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.mapper.UnitsOfMeasureMapper;
+import org.demo.whs.repository.ProductRepository;
 import org.demo.whs.repository.UnitsOfMeasureRepository;
 import org.demo.whs.service.UnitsOfMeasureService;
 import org.springframework.cache.annotation.CacheEvict;
@@ -29,6 +30,7 @@ import java.util.List;
 public class UnitsOfMeasureImpl implements UnitsOfMeasureService {
 
     private final UnitsOfMeasureRepository unitsOfMeasureRepository;
+    private final ProductRepository productRepository;
     private final UnitsOfMeasureMapper unitsOfMeasureMapper;
 
     /**
@@ -131,8 +133,12 @@ public class UnitsOfMeasureImpl implements UnitsOfMeasureService {
                     return new BadRequestException(ErrorCode.UOM_001);
                 });
 
-        // TODO: Add validation to check if UOM is referenced by products
-        // For now, proceed with hard delete
+        long referencedProducts = productRepository.countByUomId(id);
+        if (referencedProducts > 0) {
+            log.warn("Cannot delete unit of measure id {} because it is referenced by {} product(s)", id, referencedProducts);
+            throw new BadRequestException(ErrorCode.UOM_004);
+        }
+
         unitsOfMeasureRepository.delete(unitsOfMeasure);
 
         log.info("Unit of measure with id {} deleted successfully (hard delete)", id);

--- a/src/test/java/org/demo/whs/service/impl/UnitsOfMeasureImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/UnitsOfMeasureImplTest.java
@@ -8,6 +8,7 @@ import org.demo.whs.entity.enums.UnitsOfMeasureType;
 import org.demo.whs.exception.BadRequestException;
 import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.mapper.UnitsOfMeasureMapper;
+import org.demo.whs.repository.ProductRepository;
 import org.demo.whs.repository.UnitsOfMeasureRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -41,6 +42,9 @@ class UnitsOfMeasureImplTest {
 
     @Mock
     private UnitsOfMeasureMapper unitsOfMeasureMapper;
+
+    @Mock
+    private ProductRepository productRepository;
 
     @InjectMocks
     private UnitsOfMeasureImpl unitsOfMeasureService;
@@ -414,6 +418,7 @@ class UnitsOfMeasureImplTest {
                     .build();
 
             when(unitsOfMeasureRepository.findById(id)).thenReturn(Optional.of(entity));
+            when(productRepository.countByUomId(id)).thenReturn(0L);
             doNothing().when(unitsOfMeasureRepository).delete(entity);
 
             // When
@@ -421,7 +426,33 @@ class UnitsOfMeasureImplTest {
 
             // Then
             verify(unitsOfMeasureRepository).findById(id);
+            verify(productRepository).countByUomId(id);
             verify(unitsOfMeasureRepository).delete(entity);
+        }
+
+        @Test
+        @DisplayName("Should throw BadRequestException when unit of measure is referenced by products")
+        void delete_InUseByProducts() {
+            // Given
+            String id = "uom-001";
+            UnitsOfMeasure entity = UnitsOfMeasure.builder()
+                    .id(id)
+                    .code("KG")
+                    .name("Kilogram")
+                    .type(UnitsOfMeasureType.WEIGHT)
+                    .build();
+
+            when(unitsOfMeasureRepository.findById(id)).thenReturn(Optional.of(entity));
+            when(productRepository.countByUomId(id)).thenReturn(2L);
+
+            // When & Then
+            assertThatThrownBy(() -> unitsOfMeasureService.delete(id))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UOM_004.getCode());
+
+            verify(unitsOfMeasureRepository).findById(id);
+            verify(productRepository).countByUomId(id);
+            verify(unitsOfMeasureRepository, never()).delete(any());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- add business guard before UOM delete to check product references via `countByUomId`
- return domain `BadRequestException` (`UOM_004`) instead of DB FK failure
- add new error code `UOM_004` for in-use UOM delete case
- extend unit tests for both deletable and referenced UOM scenarios

## Jira
- WHS-77

## Testing
- `./mvnw test -DskipITs "-Dtest=org.demo.whs.service.impl.UnitsOfMeasureImplTest"`