### PR TITLE
fix(WHS-78): align StockAdjustments check constraint with workflow statuses

### DIFF
--- a/src/main/java/org/demo/whs/entity/StockAdjustments.java
+++ b/src/main/java/org/demo/whs/entity/StockAdjustments.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
         "AND adjustment_quantity = quantity_after - quantity_before " +
         "AND adjustment_quantity <> 0 " +
         "AND ((" +
-        "status = 'PENDING' AND approved_by IS NULL AND approved_at IS NULL AND rejection_reason IS NULL" +
+        "status = 'PENDING_APPROVAL' AND approved_by IS NULL AND approved_at IS NULL AND rejection_reason IS NULL" +
         ") OR (" +
         "status = 'APPROVED' AND approved_by IS NOT NULL AND approved_at IS NOT NULL AND rejection_reason IS NULL" +
         ") OR (" +

--- a/src/test/java/org/demo/whs/repository/StockAdjustmentsConstraintIntegrationTest.java
+++ b/src/test/java/org/demo/whs/repository/StockAdjustmentsConstraintIntegrationTest.java
@@ -63,6 +63,37 @@ class StockAdjustmentsConstraintIntegrationTest {
         assertThat(saved.getId()).isNotBlank();
     }
 
+    @Test
+    void should_RejectAdjustment_When_RejectedWithoutRejectionReason() {
+        StockAdjustments adjustment = baseAdjustment();
+        adjustment.setStatus(StockAdjustmentsStatus.REJECTED);
+        adjustment.setQuantityBefore(new BigDecimal("100.00"));
+        adjustment.setQuantityAfter(new BigDecimal("90.00"));
+        adjustment.setAdjustmentQuantity(new BigDecimal("-10.00"));
+        adjustment.setApprovedBy("acc-1");
+        adjustment.setApprovedAt(LocalDateTime.now());
+        adjustment.setRejectionReason(null);
+
+        assertThatThrownBy(() -> stockAdjustmentsRepository.saveAndFlush(adjustment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void should_SaveAdjustment_When_RejectedWithApprovalMetadataAndReason() {
+        StockAdjustments adjustment = baseAdjustment();
+        adjustment.setStatus(StockAdjustmentsStatus.REJECTED);
+        adjustment.setQuantityBefore(new BigDecimal("100.00"));
+        adjustment.setQuantityAfter(new BigDecimal("90.00"));
+        adjustment.setAdjustmentQuantity(new BigDecimal("-10.00"));
+        adjustment.setApprovedBy("acc-1");
+        adjustment.setApprovedAt(LocalDateTime.now());
+        adjustment.setRejectionReason("Count mismatch");
+
+        StockAdjustments saved = stockAdjustmentsRepository.saveAndFlush(adjustment);
+
+        assertThat(saved.getId()).isNotBlank();
+    }
+
     private StockAdjustments baseAdjustment() {
         return StockAdjustments.builder()
                 .adjustmentNumber("ADJ-TEST-" + UUID.randomUUID())


### PR DESCRIPTION
## Summary
- align entity-level `@Check` with workflow enum values by replacing `PENDING` with `PENDING_APPROVAL`
- keep status metadata invariants consistent with migration strategy
- extend constraint integration tests with rejected-state regression cases:
  - reject missing `rejectionReason` must fail
  - reject with approval metadata and reason must pass

## Jira
- WHS-78

## Testing
- `./mvnw test -DskipITs "-Dtest=org.demo.whs.repository.StockAdjustmentsConstraintIntegrationTest"`