### PR TITLE
fix(WHS-81): keep single email log record in async fallback flow

### DIFF
--- a/src/main/java/org/demo/whs/service/impl/EmailServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/EmailServiceImpl.java
@@ -119,9 +119,7 @@ public class EmailServiceImpl implements EmailService {
         // 3. Nếu không có EmailProducerService -> fallback về sync
         if (emailProducerService.isEmpty()) {
             log.warn("EmailProducerService not available, sending email synchronously instead");
-            // Gửi sync thêm 1 log khác – trường hợp này hiếm, chấp nhận duplication nhẹ
-            sendEmail(request);
-            return emailLog;
+            return sendExistingLogSynchronously(emailLog, request);
         }
 
         // 4. Đăng ký callback sau khi transaction commit
@@ -371,6 +369,32 @@ public class EmailServiceImpl implements EmailService {
     // =============================================================================
     // Private Helper Methods
     // =============================================================================
+    private EmailLog sendExistingLogSynchronously(EmailLog emailLog, SendEmailRequest request) {
+        emailLog.setStatus(EmailStatus.SENDING);
+        emailLogRepository.save(emailLog);
+
+        try {
+            sendMimeMessage(
+                    request.getRecipient(),
+                    request.getCc(),
+                    request.getBcc(),
+                    request.getSubject(),
+                    request.getContent(),
+                    request.getAttachmentPath()
+            );
+
+            emailLog.setStatus(EmailStatus.SENT);
+            emailLog.setSentAt(LocalDateTime.now());
+        } catch (Exception e) {
+            log.error("Failed to send fallback email synchronously to: {}", request.getRecipient(), e);
+            emailLog.setStatus(EmailStatus.FAILED);
+            emailLog.setErrorMessage(e.getMessage());
+            emailLog.setRetryCount(emailLog.getRetryCount() + 1);
+        }
+
+        return emailLogRepository.save(emailLog);
+    }
+
     private EmailLog createEmailLog(SendEmailRequest request) {
         EmailLog emailLog = EmailLog.builder()
                 .recipient(request.getRecipient())

--- a/src/test/java/org/demo/whs/service/impl/EmailServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/EmailServiceImplTest.java
@@ -15,17 +15,22 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import jakarta.mail.internet.MimeMessage;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -128,6 +133,80 @@ class EmailServiceImplTest {
 
     // Note: sendEmailAsync test is skipped in unit tests because it requires transaction synchronization
     // which is better tested in integration tests with @Transactional context
+
+    @Test
+    void testSendEmailAsync_WhenProducerUnavailable_UsesSingleLogRecord() {
+        // Arrange
+        EmailServiceImpl serviceWithoutProducer = new EmailServiceImpl(
+                mailSender,
+                emailLogRepository,
+                accountRepository,
+                emailProperties,
+                templateEngine,
+                Optional.empty(),
+                emailMapper
+        );
+
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        AtomicInteger idSequence = new AtomicInteger(1);
+        when(emailLogRepository.save(any(EmailLog.class))).thenAnswer(invocation -> {
+            EmailLog log = invocation.getArgument(0);
+            if (log.getId() == null) {
+                log.setId("email-" + idSequence.getAndIncrement());
+            }
+            return log;
+        });
+
+        // Act
+        EmailLog result = serviceWithoutProducer.sendEmailAsync(sendEmailRequest);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(EmailStatus.SENT, result.getStatus());
+
+        ArgumentCaptor<EmailLog> captor = ArgumentCaptor.forClass(EmailLog.class);
+        verify(emailLogRepository, times(3)).save(captor.capture());
+
+        Set<String> persistedIds = captor.getAllValues().stream()
+                .map(EmailLog::getId)
+                .collect(Collectors.toSet());
+        assertEquals(1, persistedIds.size());
+        verify(mailSender, times(1)).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void testSendEmailAsync_WhenProducerAvailable_QueuesAfterCommit() {
+        // Arrange
+        when(emailLogRepository.save(any(EmailLog.class))).thenAnswer(invocation -> {
+            EmailLog log = invocation.getArgument(0);
+            if (log.getId() == null) {
+                log.setId("email-1");
+            }
+            return log;
+        });
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            // Act
+            EmailLog result = emailService.sendEmailAsync(sendEmailRequest);
+
+            // Assert pre-commit
+            assertNotNull(result);
+            assertEquals("email-1", result.getId());
+            assertEquals(EmailStatus.PENDING, result.getStatus());
+            verify(emailLogRepository, times(1)).save(any(EmailLog.class));
+
+            List<TransactionSynchronization> synchronizations =
+                    TransactionSynchronizationManager.getSynchronizations();
+            assertEquals(1, synchronizations.size());
+
+            synchronizations.forEach(TransactionSynchronization::afterCommit);
+            verify(emailProducerService, times(1)).sendEmailToQueue(result);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
 
     @Test
     void testSendSimpleEmail() {


### PR DESCRIPTION
## Summary
- replace async fallback behavior that created a second log record via `sendEmail(request)`
- add `sendExistingLogSynchronously` helper to reuse and update the already-created pending log
- keep status transitions on one authoritative `EmailLog` record (`PENDING -> SENDING -> SENT/FAILED`)
- add unit tests for:
  - producer unavailable: no duplicate log IDs across saves
  - producer available: queue send happens after commit callback

## Jira
- WHS-81

## Testing
- `./mvnw test -DskipITs "-Dtest=org.demo.whs.service.impl.EmailServiceImplTest"`