### PR TITLE
fix(WHS-82): paginate business partner listing endpoint

### DIFF
--- a/src/main/java/org/demo/whs/controller/BusinessPartnerController.java
+++ b/src/main/java/org/demo/whs/controller/BusinessPartnerController.java
@@ -7,14 +7,13 @@ import org.demo.whs.entity.dto.request.BusinessPartner.BusinessPartnerRequest;
 import org.demo.whs.entity.dto.request.BusinessPartner.UpdateBusinessPartnerRequest;
 import org.demo.whs.entity.dto.response.BusinessPartner.BusinessPartnerResponse;
 import org.demo.whs.entity.dto.response.BaseResponse;
+import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.service.BusinessPartnerService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 /**
  * Controller for handling Business Partner APIs.
@@ -53,13 +52,19 @@ public class BusinessPartnerController {
 
     @GetMapping
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
-    public ResponseEntity<BaseResponse<List<BusinessPartnerResponse>>> getAll() {
-        log.debug("Get all business partners request");
+    public ResponseEntity<BaseResponse<PageResponse<BusinessPartnerResponse>>> getAll(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size,
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "DESC") String sortDir) {
+        log.debug("Get paginated business partners request, page={}, size={}, sortBy={}, sortDir={}",
+                page, size, sortBy, sortDir);
 
-        List<BusinessPartnerResponse> responses =
-                businessPartnerService.getAll();
+        PageResponse<BusinessPartnerResponse> responses =
+                businessPartnerService.getAll(page, size, sortBy, sortDir);
 
-        log.info("Fetched {} business partners", responses.size());
+        log.info("Fetched business partners page={}, size={}, totalElements={}",
+                responses.getPage(), responses.getSize(), responses.getTotalElements());
 
         return ResponseEntity.ok(BaseResponse.success(responses));
     }

--- a/src/main/java/org/demo/whs/service/BusinessPartnerService.java
+++ b/src/main/java/org/demo/whs/service/BusinessPartnerService.java
@@ -4,15 +4,14 @@ package org.demo.whs.service;
 import org.demo.whs.entity.dto.request.BusinessPartner.BusinessPartnerRequest;
 import org.demo.whs.entity.dto.request.BusinessPartner.UpdateBusinessPartnerRequest;
 import org.demo.whs.entity.dto.response.BusinessPartner.BusinessPartnerResponse;
-
-import java.util.List;
+import org.demo.whs.entity.dto.response.PageResponse;
 
 public interface BusinessPartnerService {
 
     /**
      * Lấy danh sách đối tác
      */
-    List<BusinessPartnerResponse> getAll();
+    PageResponse<BusinessPartnerResponse> getAll(Integer page, Integer size, String sortBy, String sortDir);
 
     /**
      * Lấy chi tiết theo id

--- a/src/main/java/org/demo/whs/service/impl/BusinessPartnerImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/BusinessPartnerImpl.java
@@ -6,14 +6,20 @@ import org.demo.whs.entity.BusinessPartners;
 import org.demo.whs.entity.dto.request.BusinessPartner.BusinessPartnerRequest;
 import org.demo.whs.entity.dto.request.BusinessPartner.UpdateBusinessPartnerRequest;
 import org.demo.whs.entity.dto.response.BusinessPartner.BusinessPartnerResponse;
+import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.enums.BusinessPartnerStatus;
+import org.demo.whs.exception.BadRequestException;
 import org.demo.whs.exception.ErrorCode;
 import org.demo.whs.mapper.BusinessPartnerMapper;
 import org.demo.whs.repository.BusinessPartnersRepository;
 import org.demo.whs.service.BusinessPartnerService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Implementation of the BusinessPartnerService interface.
@@ -29,6 +35,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BusinessPartnerImpl implements BusinessPartnerService {
 
+    private static final Set<String> ALLOWED_SORT_FIELDS = Set.of(
+            "id", "code", "name", "type", "status", "createdAt", "updatedAt"
+    );
+
     private final BusinessPartnersRepository repository;
     private final BusinessPartnerMapper mapper;
 
@@ -36,14 +46,35 @@ public class BusinessPartnerImpl implements BusinessPartnerService {
      * Retrieve all business partners.
      */
     @Override
-    public List<BusinessPartnerResponse> getAll() {
-        log.info("[SERVICE][GET_ALL] Fetching all business partners");
+    @Transactional(readOnly = true)
+    public PageResponse<BusinessPartnerResponse> getAll(Integer page, Integer size, String sortBy, String sortDir) {
+        int targetPage = page == null ? 0 : page;
+        int targetSize = size == null ? 10 : size;
 
-        List<BusinessPartners> entities = repository.findAll();
+        if (targetPage < 0) {
+            throw new BadRequestException(ErrorCode.COM_006);
+        }
+        if (targetSize <= 0) {
+            throw new BadRequestException(ErrorCode.COM_007);
+        }
+        if (targetSize > 100) {
+            throw new BadRequestException(ErrorCode.COM_008);
+        }
 
-        log.info("[SERVICE][GET_ALL] Found {} business partners", entities.size());
+        String sortField = (sortBy == null || sortBy.isBlank()) ? "createdAt" : sortBy;
+        if (!ALLOWED_SORT_FIELDS.contains(sortField)) {
+            throw new BadRequestException(ErrorCode.COM_001);
+        }
 
-        return mapper.toResponseList(entities);
+        Sort.Direction direction = "ASC".equalsIgnoreCase(sortDir) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        PageRequest pageRequest = PageRequest.of(targetPage, targetSize, Sort.by(direction, sortField));
+
+        log.info("[SERVICE][GET_ALL] Fetching business partners page={}, size={}, sortField={}, direction={}",
+                targetPage, targetSize, sortField, direction);
+
+        Page<BusinessPartners> entityPage = repository.findAll(pageRequest);
+
+        return PageResponse.from(entityPage, mapper.toResponseList(entityPage.getContent()));
     }
 
     /**

--- a/src/test/java/org/demo/whs/controller/BusinessPartnerControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/BusinessPartnerControllerTest.java
@@ -1,0 +1,100 @@
+package org.demo.whs.controller;
+
+import org.demo.whs.entity.dto.response.BusinessPartner.BusinessPartnerResponse;
+import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.exception.GlobalExceptionHandle;
+import org.demo.whs.service.BusinessPartnerService;
+import org.demo.whs.service.RateLimitService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BusinessPartnerController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import(GlobalExceptionHandle.class)
+@ImportAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        FlywayAutoConfiguration.class
+})
+class BusinessPartnerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BusinessPartnerService businessPartnerService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @Test
+    @DisplayName("Get paginated business partners should return page metadata")
+    void should_ReturnPaginatedBusinessPartners_When_RequestValid() throws Exception {
+        BusinessPartnerResponse item = BusinessPartnerResponse.builder()
+                .id("bp-1")
+                .code("BP-001")
+                .name("Partner A")
+                .build();
+
+        PageResponse<BusinessPartnerResponse> pageResponse = PageResponse.<BusinessPartnerResponse>builder()
+                .content(List.of(item))
+                .page(0)
+                .size(10)
+                .totalElements(1L)
+                .totalPages(1)
+                .isFirst(true)
+                .isLast(true)
+                .build();
+
+        when(businessPartnerService.getAll(0, 10, "createdAt", "DESC")).thenReturn(pageResponse);
+
+        mockMvc.perform(get("/api/v1/business-partners")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sortBy", "createdAt")
+                        .param("sortDir", "DESC"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(10))
+                .andExpect(jsonPath("$.data.total_elements").value(1))
+                .andExpect(jsonPath("$.data.content[0].id").value("bp-1"));
+
+        verify(businessPartnerService).getAll(0, 10, "createdAt", "DESC");
+    }
+
+    @Test
+    @DisplayName("Get paginated business partners should return 400 when size is invalid")
+    void should_ReturnBadRequest_When_SizeInvalid() throws Exception {
+        when(businessPartnerService.getAll(0, 0, "createdAt", "DESC"))
+                .thenThrow(new BadRequestException(ErrorCode.COM_007));
+
+        mockMvc.perform(get("/api/v1/business-partners")
+                        .param("page", "0")
+                        .param("size", "0")
+                        .param("sortBy", "createdAt")
+                        .param("sortDir", "DESC"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("COM_007"));
+    }
+}

--- a/src/test/java/org/demo/whs/service/impl/BusinessPartnerImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/BusinessPartnerImplTest.java
@@ -1,0 +1,102 @@
+package org.demo.whs.service.impl;
+
+import org.demo.whs.entity.BusinessPartners;
+import org.demo.whs.entity.dto.response.BusinessPartner.BusinessPartnerResponse;
+import org.demo.whs.entity.dto.response.PageResponse;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.mapper.BusinessPartnerMapper;
+import org.demo.whs.repository.BusinessPartnersRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BusinessPartnerImpl Unit Tests")
+class BusinessPartnerImplTest {
+
+    @Mock
+    private BusinessPartnersRepository repository;
+
+    @Mock
+    private BusinessPartnerMapper mapper;
+
+    @InjectMocks
+    private BusinessPartnerImpl businessPartnerService;
+
+    @Test
+    void should_ReturnPageResponse_When_PaginationValid() {
+        BusinessPartners entity = BusinessPartners.builder()
+                .code("BP-001")
+                .name("Partner A")
+                .build();
+        entity.setId("bp-1");
+
+        Page<BusinessPartners> page = new PageImpl<>(
+                List.of(entity),
+                PageRequest.of(0, 10),
+                1
+        );
+
+        BusinessPartnerResponse response = BusinessPartnerResponse.builder()
+                .id("bp-1")
+                .code("BP-001")
+                .name("Partner A")
+                .build();
+
+        when(repository.findAll(any(PageRequest.class))).thenReturn(page);
+        when(mapper.toResponseList(page.getContent())).thenReturn(List.of(response));
+
+        PageResponse<BusinessPartnerResponse> result =
+                businessPartnerService.getAll(0, 10, "createdAt", "DESC");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getPage()).isEqualTo(0);
+        assertThat(result.getSize()).isEqualTo(10);
+        verify(repository).findAll(any(PageRequest.class));
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_PageLessThanZero() {
+        assertThatThrownBy(() -> businessPartnerService.getAll(-1, 10, "createdAt", "DESC"))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COM_006.getCode());
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_SizeLessThanOrEqualToZero() {
+        assertThatThrownBy(() -> businessPartnerService.getAll(0, 0, "createdAt", "DESC"))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COM_007.getCode());
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_SizeGreaterThanHundred() {
+        assertThatThrownBy(() -> businessPartnerService.getAll(0, 101, "createdAt", "DESC"))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COM_008.getCode());
+    }
+
+    @Test
+    void should_ThrowBadRequest_When_SortByNotAllowed() {
+        assertThatThrownBy(() -> businessPartnerService.getAll(0, 10, "unknownField", "DESC"))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COM_001.getCode());
+    }
+}


### PR DESCRIPTION
## Summary
- change business-partner list contract from full-table list to paginated response
- add `page/size/sortBy/sortDir` parameters on `GET /api/v1/business-partners`
- return `BaseResponse<PageResponse<BusinessPartnerResponse>>` with page metadata
- implement pagination and boundary validation (`COM_006/007/008`) in service
- validate allowed sort fields and return `COM_001` for invalid sort keys
- add controller and service unit tests for paging behavior and boundary values

## Jira
- WHS-82

## Testing
- `./mvnw test -DskipITs "-Dtest=org.demo.whs.service.impl.BusinessPartnerImplTest,org.demo.whs.controller.BusinessPartnerControllerTest"`