### PR TITLE
WHS-41: implement Batch lifecycle APIs

### DIFF
--- a/src/main/java/org/demo/whs/service/impl/BatchServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/BatchServiceImpl.java
@@ -81,12 +81,15 @@ public class BatchServiceImpl implements BatchService {
             throw new BadRequestException(ErrorCode.BATCH_006);
         }
 
+        Account currentUser = getCurrentUser();
+
         Batch batch = batchMapper.createEntity(request);
         batch.setStatus(BatchStatus.AVAILABLE);
+        setAuditFieldsForCreate(batch, currentUser);
 
         Batch savedBatch = batchRepository.save(batch);
 
-        log.info("Batch created successfully with ID={}", savedBatch.getId());
+        log.info("Batch created successfully with ID={} by user={}", savedBatch.getId(), currentUser.getUsername());
 
         return batchMapper.toResponse(savedBatch);
     }
@@ -157,7 +160,12 @@ public class BatchServiceImpl implements BatchService {
 
         batchMapper.updateEntity(request, batch);
 
+        Account currentUser = getCurrentUser();
+        setAuditFieldsForUpdate(batch, currentUser);
+
         Batch updateBatch = batchRepository.save(batch);
+
+        log.info("Batch updated successfully with ID={} by user={}", updateBatch.getId(), currentUser.getUsername());
 
         return batchMapper.toResponse(updateBatch);
     }
@@ -202,6 +210,9 @@ public class BatchServiceImpl implements BatchService {
         setAuditFieldsForUpdate(batch, user);
 
         Batch savedBatch = batchRepository.save(batch);
+
+        log.info("Batch {} released from QUARANTINE by user {}",
+                batch.getBatchNumber(), user.getUsername());
 
         return batchMapper.toResponse(savedBatch);
     }
@@ -277,6 +288,11 @@ public class BatchServiceImpl implements BatchService {
 
     private String buildReleaseAuditNote(ReleaseBatchRequest request) {
         return "[RELEASE] release_notes=" + request.getReleaseNotes();
+    }
+
+    private void setAuditFieldsForCreate(Batch batch, Account user) {
+        batch.setCreatedBy(user.getId());
+        batch.setUpdatedBy(user.getId());
     }
 
     /**

--- a/src/test/java/org/demo/whs/controller/BatchControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/BatchControllerTest.java
@@ -1,0 +1,207 @@
+package org.demo.whs.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.demo.whs.entity.dto.response.Batch.BatchResponse;
+import org.demo.whs.entity.enums.BatchStatus;
+import org.demo.whs.exception.BadRequestException;
+import org.demo.whs.exception.ErrorCode;
+import org.demo.whs.exception.GlobalExceptionHandle;
+import org.demo.whs.service.BatchService;
+import org.demo.whs.service.RateLimitService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BatchController.class)
+@ActiveProfiles("test")
+@WithMockUser
+@Import({BatchControllerTest.TestSecurityConfig.class, GlobalExceptionHandle.class})
+@ImportAutoConfiguration(JacksonAutoConfiguration.class)
+class BatchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private BatchService batchService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @Test
+    @DisplayName("Should update batch when request is valid")
+    void should_UpdateBatch_When_RequestIsValid() throws Exception {
+        when(batchService.updateBatch(eq("batch-1"), any())).thenReturn(buildResponse("batch-1", BatchStatus.AVAILABLE));
+
+        mockMvc.perform(put("/api/v1/batches/{id}", "batch-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "notes", "Updated batch note"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value("batch-1"))
+                .andExpect(jsonPath("$.message").value("Batch updated successfully"));
+
+        verify(batchService).updateBatch(eq("batch-1"), any());
+    }
+
+    @Test
+    @DisplayName("Should quarantine batch when request is valid")
+    void should_QuarantineBatch_When_RequestIsValid() throws Exception {
+        when(batchService.quarantineBatch(eq("batch-1"), any()))
+                .thenReturn(buildResponse("batch-1", BatchStatus.QUARANTINE));
+
+        mockMvc.perform(put("/api/v1/batches/{id}/quarantine", "batch-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "reason", "Quality issue found",
+                                "notify_manager", true
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("QUARANTINE"))
+                .andExpect(jsonPath("$.message").value("Batch quarantined successfully"));
+
+        verify(batchService).quarantineBatch(eq("batch-1"), any());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when quarantine request misses reason")
+    void should_Return400_When_QuarantineRequestMissesReason() throws Exception {
+        mockMvc.perform(put("/api/v1/batches/{id}/quarantine", "batch-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "notify_manager", true
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
+
+        verify(batchService, never()).quarantineBatch(any(), any());
+    }
+
+    @Test
+    @DisplayName("Should release batch when request is valid")
+    void should_ReleaseBatch_When_RequestIsValid() throws Exception {
+        when(batchService.releaseBatch(eq("batch-1"), any()))
+                .thenReturn(buildResponse("batch-1", BatchStatus.AVAILABLE));
+
+        mockMvc.perform(put("/api/v1/batches/{id}/release", "batch-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "release_notes", "Quality issue resolved"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.message").value("Batch released successfully"));
+
+        verify(batchService).releaseBatch(eq("batch-1"), any());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when release request misses notes")
+    void should_Return400_When_ReleaseRequestMissesNotes() throws Exception {
+        mockMvc.perform(put("/api/v1/batches/{id}/release", "batch-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
+
+        verify(batchService, never()).releaseBatch(any(), any());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when generic status patch is blocked")
+    void should_Return400_When_GenericStatusPatchIsBlocked() throws Exception {
+        when(batchService.changeBatchStatus(eq("batch-1"), any()))
+                .thenThrow(new BadRequestException(ErrorCode.BATCH_011));
+
+        mockMvc.perform(patch("/api/v1/batches/{id}/status", "batch-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "status", "EXPIRED"
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error_code").value("BATCH_011"));
+
+        verify(batchService).changeBatchStatus(eq("batch-1"), any());
+    }
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("Should return 403 when quarantine is called without authentication")
+    void should_Return403_When_QuarantineWithoutAuthentication() throws Exception {
+        mockMvc.perform(put("/api/v1/batches/{id}/quarantine", "batch-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "reason", "Quality issue found"
+                        ))))
+                .andExpect(status().isForbidden());
+
+        verify(batchService, never()).quarantineBatch(any(), any());
+    }
+
+    private BatchResponse buildResponse(String id, BatchStatus status) {
+        return BatchResponse.builder()
+                .id(id)
+                .batchNumber("BATCH-001")
+                .productId("prod-1")
+                .manufacturingDate(LocalDate.now().minusDays(5))
+                .expiryDate(LocalDate.now().plusDays(30))
+                .status(status)
+                .createdBy("user-1")
+                .createdAt(LocalDateTime.now())
+                .updatedBy("user-1")
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                    .formLogin(AbstractHttpConfigurer::disable)
+                    .httpBasic(AbstractHttpConfigurer::disable);
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/demo/whs/service/impl/BatchServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/BatchServiceImplTest.java
@@ -7,6 +7,7 @@ import org.demo.whs.entity.dto.request.Batch.ChangeBatchStatusRequest;
 import org.demo.whs.entity.dto.request.Batch.CreateBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.QuarantineBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.ReleaseBatchRequest;
+import org.demo.whs.entity.dto.request.Batch.UpdateBatchRequest;
 import org.demo.whs.entity.dto.response.Batch.BatchResponse;
 import org.demo.whs.entity.enums.BatchStatus;
 import org.demo.whs.exception.BadRequestException;
@@ -29,6 +30,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,6 +70,10 @@ class BatchServiceImplTest {
         product.setId("P1");
         product.setRequiresBatchTracking(true);
 
+        Account account = new Account();
+        account.setId("A1");
+        account.setUsername("admin");
+
         Batch batch = new Batch();
         Batch savedBatch = new Batch();
         savedBatch.setId("BATCH_1");
@@ -81,13 +88,20 @@ class BatchServiceImplTest {
         when(batchRepository.save(batch)).thenReturn(savedBatch);
         when(batchMapper.toResponse(savedBatch)).thenReturn(response);
 
-        BatchResponse result = batchService.createBatch(request);
+        try (var mocked = mockStatic(SecurityUtils.class)) {
+            mocked.when(SecurityUtils::getCurrentUsername).thenReturn("admin");
+            when(accountRepository.findByUsername("admin")).thenReturn(Optional.of(account));
 
-        assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo("BATCH_1");
-        assertThat(batch.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
+            BatchResponse result = batchService.createBatch(request);
 
-        verify(batchRepository).save(batch);
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo("BATCH_1");
+            assertThat(batch.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
+            assertThat(batch.getCreatedBy()).isEqualTo("A1");
+            assertThat(batch.getUpdatedBy()).isEqualTo("A1");
+
+            verify(batchRepository).save(batch);
+        }
     }
 
     @Test
@@ -185,6 +199,57 @@ class BatchServiceImplTest {
         assertThatThrownBy(() -> batchService.createBatch(request))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining(ErrorCode.BATCH_006.getMessage());
+    }
+
+    @Test
+    void updateBatch_success() {
+        Batch batch = new Batch();
+        batch.setId("B1");
+        batch.setProductId("P1");
+        batch.setBatchNumber("B001");
+        batch.setManufacturingDate(LocalDate.now().minusDays(2));
+        batch.setExpiryDate(LocalDate.now().plusDays(20));
+
+        UpdateBatchRequest request = new UpdateBatchRequest();
+        request.setBatchNumber("B002");
+        request.setSupplierBatchNumber("SUP-01");
+        request.setNotes("Updated notes");
+
+        Account account = new Account();
+        account.setId("A1");
+        account.setUsername("admin");
+
+        BatchResponse response = BatchResponse.builder()
+                .id("B1")
+                .batchNumber("B002")
+                .build();
+
+        when(batchRepository.findById("B1")).thenReturn(Optional.of(batch));
+        when(batchRepository.existsByProductIdAndBatchNumberAndIdNot("P1", "B002", "B1")).thenReturn(false);
+        doAnswer(invocation -> {
+            UpdateBatchRequest updateRequest = invocation.getArgument(0);
+            Batch target = invocation.getArgument(1);
+            target.setBatchNumber(updateRequest.getBatchNumber());
+            target.setSupplierBatchNumber(updateRequest.getSupplierBatchNumber());
+            target.setNotes(updateRequest.getNotes());
+            return null;
+        }).when(batchMapper).updateEntity(any(UpdateBatchRequest.class), any(Batch.class));
+        when(batchRepository.save(batch)).thenReturn(batch);
+        when(batchMapper.toResponse(batch)).thenReturn(response);
+
+        try (var mocked = mockStatic(SecurityUtils.class)) {
+            mocked.when(SecurityUtils::getCurrentUsername).thenReturn("admin");
+            when(accountRepository.findByUsername("admin")).thenReturn(Optional.of(account));
+
+            BatchResponse result = batchService.updateBatch("B1", request);
+
+            assertThat(result).isNotNull();
+            assertThat(batch.getBatchNumber()).isEqualTo("B002");
+            assertThat(batch.getSupplierBatchNumber()).isEqualTo("SUP-01");
+            assertThat(batch.getNotes()).isEqualTo("Updated notes");
+            assertThat(batch.getUpdatedBy()).isEqualTo("A1");
+            assertThat(batch.getUpdatedAt()).isNotNull();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- implement the Batch lifecycle mutation flow for update, quarantine, and release
- enforce explicit status transitions through dedicated workflow endpoints
- harden service-level validation around Batch lifecycle operations

## Context
This PR is the second step of the sequenced `WHS-35` Batch delivery.
Baseline `WHS-83` has already been merged into `develop`.

## Jira
- `WHS-41`
- parent: `WHS-35`