### PR TITLE
WHS-42: implement Batch traceability and query APIs

### DIFF
--- a/documents/Batch/WHS-42_BATCH_QUERY_APIS_20260315.md
+++ b/documents/Batch/WHS-42_BATCH_QUERY_APIS_20260315.md
@@ -1,0 +1,49 @@
+# WHS-42 Batch Query APIs - 2026-03-15
+
+## Scope
+Implemented 4 Batch read-side APIs on `feature/dunghd/WHS-42`:
+
+- `GET /api/v1/batches/{id}/traceability`
+- `GET /api/v1/batches/expiring`
+- `GET /api/v1/batches/fifo-recommendations`
+- `GET /api/v1/batches/by-product/{productId}`
+
+## Business Rules
+
+### Traceability
+- Returns only data that already exists in the system.
+- Assembles batch master data, current inventory snapshot, inbound history, outbound history, and stock movements.
+- Workflow notes are parsed only from stored `batch.notes` lines starting with `[QUARANTINE]` or `[RELEASE]`.
+- Does not fabricate a separate audit log because the system does not currently have a dedicated batch audit table.
+
+### Expiring
+- Uses configurable `threshold_days`, default `30`.
+- Includes only batches with `expiry_date` within `[today, today + threshold]`.
+- Includes only statuses `AVAILABLE` and `QUARANTINE`.
+- Excludes batches with no physical stock remaining.
+- Supports optional `warehouse_id` filter.
+- Returns urgency bands:
+  - `CRITICAL` when days to expiry `<= 7`
+  - `WARNING` when days to expiry `<= 14`
+  - `INFO` otherwise
+
+### FIFO Recommendations
+- Requires `product_id` and `warehouse_id`.
+- Product must exist and have `requires_batch_tracking = true`.
+- Warehouse must exist.
+- Recommends only batches that are:
+  - `AVAILABLE`
+  - not expired on the query date
+  - have positive available quantity in the requested warehouse
+- Sort order follows the batch repository contract by manufacturing date, then expiry date.
+- Response includes rank and inventory snapshot per recommended batch.
+
+### By Product
+- Requires a batch-tracked product.
+- Supports optional `warehouse_id` filter.
+- Without warehouse filter: returns all batches for the product with inventory summary.
+- With warehouse filter: returns only batches that currently have inventory rows in that warehouse.
+
+## Verification
+- `./mvnw -DskipTests compile`
+- `./mvnw test -DskipITs "-Dtest=org.demo.whs.service.impl.BatchServiceImplTest,org.demo.whs.controller.BatchControllerTest,org.demo.whs.service.impl.BatchQueryServiceImplTest,org.demo.whs.controller.BatchQueryControllerTest"`

--- a/src/main/java/org/demo/whs/controller/BatchController.java
+++ b/src/main/java/org/demo/whs/controller/BatchController.java
@@ -3,6 +3,9 @@ package org.demo.whs.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.dto.request.Batch.ChangeBatchStatusRequest;
@@ -11,7 +14,11 @@ import org.demo.whs.entity.dto.request.Batch.QuarantineBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.ReleaseBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.UpdateBatchRequest;
 import org.demo.whs.entity.dto.response.BaseResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchByProductResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchExpiringResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchFifoRecommendationResponse;
 import org.demo.whs.entity.dto.response.Batch.BatchResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchTraceabilityResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.service.BatchService;
 import org.springframework.http.HttpStatus;
@@ -27,6 +34,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequestMapping("/api/v1/batches")
 @RestController
@@ -72,6 +81,41 @@ public class BatchController {
         BaseResponse<PageResponse<BatchResponse>> baseResponse = BaseResponse.success(response);
 
         return ResponseEntity.ok(baseResponse);
+    }
+
+    @GetMapping("/{id}/traceability")
+    @Operation(summary = "Get batch traceability", description = "Display complete batch traceability from receipt to shipment")
+    public ResponseEntity<BaseResponse<BatchTraceabilityResponse>> getBatchTraceability(@PathVariable String id) {
+        BatchTraceabilityResponse response = batchService.getBatchTraceability(id);
+        return ResponseEntity.ok(BaseResponse.success(response, "Batch traceability retrieved successfully"));
+    }
+
+    @GetMapping("/expiring")
+    @Operation(summary = "Get expiring batches", description = "List batches approaching expiry that still have stock")
+    public ResponseEntity<BaseResponse<List<BatchExpiringResponse>>> getExpiringBatches(
+            @RequestParam(name = "threshold_days", defaultValue = "30") @Min(0) Integer thresholdDays,
+            @RequestParam(name = "warehouse_id", required = false) String warehouseId) {
+        List<BatchExpiringResponse> response = batchService.getExpiringBatches(thresholdDays, warehouseId);
+        return ResponseEntity.ok(BaseResponse.success(response, "Expiring batches retrieved successfully"));
+    }
+
+    @GetMapping("/fifo-recommendations")
+    @Operation(summary = "Get FIFO recommendations", description = "Recommend oldest eligible batches for outbound picking")
+    public ResponseEntity<BaseResponse<List<BatchFifoRecommendationResponse>>> getFifoRecommendations(
+            @RequestParam(name = "product_id") @NotBlank String productId,
+            @RequestParam(name = "warehouse_id") @NotBlank String warehouseId,
+            @RequestParam(name = "limit", defaultValue = "5") @Min(1) @Max(50) Integer limit) {
+        List<BatchFifoRecommendationResponse> response = batchService.getFifoRecommendations(productId, warehouseId, limit);
+        return ResponseEntity.ok(BaseResponse.success(response, "FIFO recommendations retrieved successfully"));
+    }
+
+    @GetMapping("/by-product/{productId}")
+    @Operation(summary = "Get batches by product", description = "List all batches for a product with inventory summary")
+    public ResponseEntity<BaseResponse<List<BatchByProductResponse>>> getBatchesByProduct(
+            @PathVariable String productId,
+            @RequestParam(name = "warehouse_id", required = false) String warehouseId) {
+        List<BatchByProductResponse> response = batchService.getBatchesByProduct(productId, warehouseId);
+        return ResponseEntity.ok(BaseResponse.success(response, "Batches retrieved successfully"));
     }
 
     @PatchMapping("/{id}/status")

--- a/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchByProductResponse.java
+++ b/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchByProductResponse.java
@@ -1,0 +1,31 @@
+package org.demo.whs.entity.dto.response.Batch;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.demo.whs.entity.enums.BatchStatus;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BatchByProductResponse {
+
+    private String batchId;
+    private String batchNumber;
+    private String productId;
+    private String productSku;
+    private String productName;
+    private BatchStatus status;
+    private LocalDate manufacturingDate;
+    private LocalDate expiryDate;
+    private String supplierBatchNumber;
+    private String notes;
+    private BatchInventorySnapshotResponse inventorySnapshot;
+}

--- a/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchExpiringResponse.java
+++ b/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchExpiringResponse.java
@@ -1,0 +1,31 @@
+package org.demo.whs.entity.dto.response.Batch;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.demo.whs.entity.enums.BatchStatus;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BatchExpiringResponse {
+
+    private String batchId;
+    private String batchNumber;
+    private String productId;
+    private String productSku;
+    private String productName;
+    private BatchStatus status;
+    private LocalDate manufacturingDate;
+    private LocalDate expiryDate;
+    private Long daysToExpiry;
+    private String urgency;
+    private BatchInventorySnapshotResponse inventorySnapshot;
+}

--- a/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchFifoRecommendationResponse.java
+++ b/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchFifoRecommendationResponse.java
@@ -1,0 +1,34 @@
+package org.demo.whs.entity.dto.response.Batch;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.demo.whs.entity.enums.BatchStatus;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BatchFifoRecommendationResponse {
+
+    private Integer recommendationRank;
+    private String batchId;
+    private String batchNumber;
+    private String productId;
+    private String productSku;
+    private String productName;
+    private String warehouseId;
+    private String warehouseCode;
+    private String warehouseName;
+    private BatchStatus status;
+    private LocalDate manufacturingDate;
+    private LocalDate expiryDate;
+    private Long daysToExpiry;
+    private BatchInventorySnapshotResponse inventorySnapshot;
+}

--- a/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchInventorySnapshotResponse.java
+++ b/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchInventorySnapshotResponse.java
@@ -1,0 +1,61 @@
+package org.demo.whs.entity.dto.response.Batch;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BatchInventorySnapshotResponse {
+
+    private BigDecimal totalOnHandQuantity;
+    private BigDecimal totalQuarantineQuantity;
+    private BigDecimal totalReservedQuantity;
+    private BigDecimal totalAvailableQuantity;
+    private Long warehouseCount;
+    private Long locationCount;
+    private List<WarehouseInventoryResponse> warehouses;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class WarehouseInventoryResponse {
+        private String warehouseId;
+        private String warehouseCode;
+        private String warehouseName;
+        private BigDecimal onHandQuantity;
+        private BigDecimal quarantineQuantity;
+        private BigDecimal reservedQuantity;
+        private BigDecimal availableQuantity;
+        private Long locationCount;
+        private List<LocationInventoryResponse> locations;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class LocationInventoryResponse {
+        private String locationId;
+        private String locationCode;
+        private String locationName;
+        private BigDecimal onHandQuantity;
+        private BigDecimal quarantineQuantity;
+        private BigDecimal reservedQuantity;
+        private BigDecimal availableQuantity;
+        private LocalDateTime lastMovementAt;
+    }
+}

--- a/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchTraceabilityResponse.java
+++ b/src/main/java/org/demo/whs/entity/dto/response/Batch/BatchTraceabilityResponse.java
@@ -1,0 +1,123 @@
+package org.demo.whs.entity.dto.response.Batch;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.demo.whs.entity.enums.BatchStatus;
+import org.demo.whs.entity.enums.InboundReceiptsStatus;
+import org.demo.whs.entity.enums.OutboundShipmentsStatus;
+import org.demo.whs.entity.enums.QualityStatus;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.demo.whs.entity.enums.StockMovementsType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BatchTraceabilityResponse {
+
+    private String batchId;
+    private String batchNumber;
+    private String productId;
+    private String productSku;
+    private String productName;
+    private BatchStatus status;
+    private LocalDate manufacturingDate;
+    private LocalDate expiryDate;
+    private String supplierBatchNumber;
+    private String notes;
+    private BatchInventorySnapshotResponse inventorySnapshot;
+    private List<InboundTraceabilityEvent> inboundReceipts;
+    private List<OutboundTraceabilityEvent> outboundShipments;
+    private List<StockMovementTraceabilityEvent> stockMovements;
+    private List<String> workflowNotes;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class InboundTraceabilityEvent {
+        private String inboundReceiptId;
+        private String receiptNumber;
+        private LocalDate receiptDate;
+        private InboundReceiptsStatus receiptStatus;
+        private String purchaseOrderId;
+        private String purchaseOrderNumber;
+        private String supplierId;
+        private String supplierCode;
+        private String supplierName;
+        private String warehouseId;
+        private String warehouseCode;
+        private String warehouseName;
+        private String locationId;
+        private String locationCode;
+        private String locationName;
+        private BigDecimal quantityReceived;
+        private QualityStatus qualityStatus;
+        private String notes;
+        private LocalDateTime createdAt;
+        private LocalDateTime confirmedAt;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class OutboundTraceabilityEvent {
+        private String outboundShipmentId;
+        private String shipmentNumber;
+        private LocalDate shipmentDate;
+        private OutboundShipmentsStatus shipmentStatus;
+        private String salesOrderId;
+        private String salesOrderNumber;
+        private String customerId;
+        private String customerCode;
+        private String customerName;
+        private String warehouseId;
+        private String warehouseCode;
+        private String warehouseName;
+        private String locationId;
+        private String locationCode;
+        private String locationName;
+        private BigDecimal quantityShipped;
+        private LocalDateTime pickedAt;
+        private String notes;
+        private LocalDateTime createdAt;
+        private LocalDateTime shippedAt;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class StockMovementTraceabilityEvent {
+        private String stockMovementId;
+        private StockMovementsType movementType;
+        private LocalDateTime movementDate;
+        private String warehouseId;
+        private String warehouseCode;
+        private String warehouseName;
+        private String locationId;
+        private String locationCode;
+        private String locationName;
+        private BigDecimal quantityChange;
+        private BigDecimal quantityBefore;
+        private BigDecimal quantityAfter;
+        private ReferenceType referenceType;
+        private String referenceId;
+        private String referenceNumber;
+        private String notes;
+    }
+}

--- a/src/main/java/org/demo/whs/repository/BatchRepository.java
+++ b/src/main/java/org/demo/whs/repository/BatchRepository.java
@@ -1,10 +1,15 @@
 package org.demo.whs.repository;
 
 import org.demo.whs.entity.Batch;
+import org.demo.whs.entity.enums.BatchStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -33,15 +38,24 @@ public interface BatchRepository extends JpaRepository<Batch, String> {
      */
     Optional<Batch> findByBatchNumber(String batchNumber);
 
-    /**
-     *
-     * @param productId
-     * @param batchNumber
-     * @param id
-     * @return
-     */
     boolean existsByProductIdAndBatchNumberAndIdNot(String productId, String batchNumber, String id);
 
-    @Query(value = "SELECT b FROM Batch b WHERE b.productId = :productId AND b.id = :batchId")
-    Optional<Object> findByProductIdAndBatchId(String productId, String batchId);
+    @Query("SELECT b FROM Batch b WHERE b.productId = :productId AND b.id = :batchId")
+    Optional<Object> findByProductIdAndBatchId(@Param("productId") String productId, @Param("batchId") String batchId);
+
+    List<Batch> findByProductIdOrderByManufacturingDateAscExpiryDateAscCreatedAtAsc(String productId);
+
+    @Query("""
+           SELECT b
+           FROM Batch b
+           WHERE b.expiryDate IS NOT NULL
+             AND b.expiryDate BETWEEN :startDate AND :endDate
+             AND b.status IN :statuses
+           ORDER BY b.expiryDate ASC, b.manufacturingDate ASC, b.createdAt ASC
+           """)
+    List<Batch> findExpiringBatches(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("statuses") Collection<BatchStatus> statuses
+    );
 }

--- a/src/main/java/org/demo/whs/repository/InboundReceiptLinesRepository.java
+++ b/src/main/java/org/demo/whs/repository/InboundReceiptLinesRepository.java
@@ -2,7 +2,6 @@ package org.demo.whs.repository;
 
 import jakarta.persistence.LockModeType;
 import org.demo.whs.entity.InboundReceiptLines;
-import org.demo.whs.entity.enums.InboundReceiptsStatus;
 import org.demo.whs.entity.enums.QualityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -19,8 +18,10 @@ public interface InboundReceiptLinesRepository extends JpaRepository<InboundRece
 
     List<InboundReceiptLines> findByInboundReceiptIdOrderByLineNumberAsc(String inboundReceiptId);
 
+    List<InboundReceiptLines> findByBatchIdOrderByCreatedAtDesc(String batchId);
+
     @Query(value = "SELECT COUNT(*) FROM inbound_receipt_lines WHERE inbound_receipt_id = :inboundReceiptId", nativeQuery = true)
-    long countByInboundReceiptId(String inboundReceiptId);
+    long countByInboundReceiptId(@Param("inboundReceiptId") String inboundReceiptId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select irl from InboundReceiptLines irl where irl.id = :id")

--- a/src/main/java/org/demo/whs/repository/InventoryRepository.java
+++ b/src/main/java/org/demo/whs/repository/InventoryRepository.java
@@ -1,5 +1,6 @@
 package org.demo.whs.repository;
 
+import jakarta.persistence.LockModeType;
 import org.demo.whs.entity.Inventory;
 import org.demo.whs.repository.custom.InventoryRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,7 +9,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import jakarta.persistence.LockModeType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,6 +28,7 @@ public interface InventoryRepository extends
         WHERE i.id = :id
     """)
     Optional<Inventory> findByIdForUpdate(@Param("id") String id);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
         SELECT i
@@ -107,8 +109,13 @@ public interface InventoryRepository extends
      * Find inventory by product, warehouse, location, and batch.
      * Used for validation or retrieval when all dimensions are specified.
      */
-    @Query(value = "SELECT i FROM Inventory i WHERE i.productId = :productId AND i.warehouseId = :warehouseId AND i.locationId = :locationId AND i.batchId = :batchId")
-    Optional<Object> findByProductIdAndWarehouseIdAndLocationIdAndBatchId(String productId, String warehouseId, String locationId, String batchId);
+    @Query("SELECT i FROM Inventory i WHERE i.productId = :productId AND i.warehouseId = :warehouseId AND i.locationId = :locationId AND i.batchId = :batchId")
+    Optional<Object> findByProductIdAndWarehouseIdAndLocationIdAndBatchId(
+            @Param("productId") String productId,
+            @Param("warehouseId") String warehouseId,
+            @Param("locationId") String locationId,
+            @Param("batchId") String batchId
+    );
 
     @Query("""
            SELECT CASE WHEN COUNT(i) > 0 THEN true ELSE false END
@@ -116,5 +123,15 @@ public interface InventoryRepository extends
            WHERE i.batchId = :batchId
            AND i.reservedQuantity > 0
            """)
-    boolean existsReservedStockByBatchId(String batchId);
+    boolean existsReservedStockByBatchId(@Param("batchId") String batchId);
+
+    List<Inventory> findByBatchIdOrderByLastMovementAtDesc(String batchId);
+
+    List<Inventory> findByBatchIdIn(Collection<String> batchIds);
+
+    List<Inventory> findByWarehouseIdAndBatchIdIn(String warehouseId, Collection<String> batchIds);
+
+    List<Inventory> findByProductIdAndBatchIdIn(String productId, Collection<String> batchIds);
+
+    List<Inventory> findByProductIdAndWarehouseIdAndBatchIdIn(String productId, String warehouseId, Collection<String> batchIds);
 }

--- a/src/main/java/org/demo/whs/repository/OutboundShipmentLinesRepository.java
+++ b/src/main/java/org/demo/whs/repository/OutboundShipmentLinesRepository.java
@@ -4,9 +4,13 @@ import org.demo.whs.entity.OutboundShipmentLines;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 /**
  * Repository interface for OutboundShipmentLines entity.
  */
 @Repository
 public interface OutboundShipmentLinesRepository extends JpaRepository<OutboundShipmentLines, String> {
+
+    List<OutboundShipmentLines> findByBatchIdOrderByCreatedAtDesc(String batchId);
 }

--- a/src/main/java/org/demo/whs/repository/StockMovementsRepository.java
+++ b/src/main/java/org/demo/whs/repository/StockMovementsRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 /**
  * Repository interface for StockMovements entity.
  */
@@ -22,4 +24,6 @@ public interface StockMovementsRepository extends JpaRepository<StockMovements, 
     boolean existsByReferenceTypeAndReferenceId(ReferenceType referenceType, String referenceId);
 
     boolean existsByReferenceTypeAndReferenceNumber(ReferenceType referenceType, String referenceNumber);
+
+    List<StockMovements> findByBatchIdOrderByMovementDateDesc(String batchId);
 }

--- a/src/main/java/org/demo/whs/service/BatchService.java
+++ b/src/main/java/org/demo/whs/service/BatchService.java
@@ -5,8 +5,14 @@ import org.demo.whs.entity.dto.request.Batch.CreateBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.QuarantineBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.ReleaseBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.UpdateBatchRequest;
+import org.demo.whs.entity.dto.response.Batch.BatchByProductResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchExpiringResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchFifoRecommendationResponse;
 import org.demo.whs.entity.dto.response.Batch.BatchResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchTraceabilityResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
+
+import java.util.List;
 
 /**
  * Service interface for batch operations.
@@ -26,4 +32,12 @@ public interface BatchService {
     BatchResponse quarantineBatch(String id, QuarantineBatchRequest request);
 
     BatchResponse releaseBatch(String id, ReleaseBatchRequest request);
+
+    BatchTraceabilityResponse getBatchTraceability(String id);
+
+    List<BatchExpiringResponse> getExpiringBatches(Integer thresholdDays, String warehouseId);
+
+    List<BatchFifoRecommendationResponse> getFifoRecommendations(String productId, String warehouseId, Integer limit);
+
+    List<BatchByProductResponse> getBatchesByProduct(String productId, String warehouseId);
 }

--- a/src/main/java/org/demo/whs/service/impl/BatchServiceImpl.java
+++ b/src/main/java/org/demo/whs/service/impl/BatchServiceImpl.java
@@ -4,14 +4,31 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.whs.entity.Account;
+import org.demo.whs.entity.BaseEntity;
 import org.demo.whs.entity.Batch;
+import org.demo.whs.entity.BusinessPartners;
+import org.demo.whs.entity.InboundReceiptLines;
+import org.demo.whs.entity.InboundReceipts;
+import org.demo.whs.entity.Inventory;
+import org.demo.whs.entity.Locations;
+import org.demo.whs.entity.OutboundShipmentLines;
+import org.demo.whs.entity.OutboundShipments;
 import org.demo.whs.entity.Products;
+import org.demo.whs.entity.PurchaseOrders;
+import org.demo.whs.entity.SalesOrders;
+import org.demo.whs.entity.StockMovements;
+import org.demo.whs.entity.Warehouses;
 import org.demo.whs.entity.dto.request.Batch.ChangeBatchStatusRequest;
 import org.demo.whs.entity.dto.request.Batch.CreateBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.QuarantineBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.ReleaseBatchRequest;
 import org.demo.whs.entity.dto.request.Batch.UpdateBatchRequest;
+import org.demo.whs.entity.dto.response.Batch.BatchByProductResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchExpiringResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchFifoRecommendationResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchInventorySnapshotResponse;
 import org.demo.whs.entity.dto.response.Batch.BatchResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchTraceabilityResponse;
 import org.demo.whs.entity.dto.response.PageResponse;
 import org.demo.whs.entity.enums.BatchStatus;
 import org.demo.whs.exception.BadRequestException;
@@ -20,8 +37,18 @@ import org.demo.whs.exception.NotFoundException;
 import org.demo.whs.mapper.BatchMapper;
 import org.demo.whs.repository.AccountRepository;
 import org.demo.whs.repository.BatchRepository;
+import org.demo.whs.repository.BusinessPartnersRepository;
+import org.demo.whs.repository.InboundReceiptLinesRepository;
+import org.demo.whs.repository.InboundReceiptsRepository;
 import org.demo.whs.repository.InventoryRepository;
+import org.demo.whs.repository.LocationRepository;
+import org.demo.whs.repository.OutboundShipmentLinesRepository;
+import org.demo.whs.repository.OutboundShipmentsRepository;
 import org.demo.whs.repository.ProductRepository;
+import org.demo.whs.repository.PurchaseOrdersRepository;
+import org.demo.whs.repository.SalesOrdersRepository;
+import org.demo.whs.repository.StockMovementsRepository;
+import org.demo.whs.repository.WareHouseRepository;
 import org.demo.whs.security.SecurityUtils;
 import org.demo.whs.service.BatchService;
 import org.springframework.data.domain.Page;
@@ -30,67 +57,77 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/**
- * Implementation of the BatchService interface.
- */
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class BatchServiceImpl implements BatchService {
+
+    private static final List<BatchStatus> EXPIRING_BATCH_STATUSES = List.of(
+            BatchStatus.AVAILABLE,
+            BatchStatus.QUARANTINE
+    );
+    private static final String NO_LOCATION_KEY = "__NO_LOCATION__";
 
     private final AccountRepository accountRepository;
     private final InventoryRepository inventoryRepository;
     private final ProductRepository productRepository;
     private final BatchRepository batchRepository;
     private final BatchMapper batchMapper;
+    private final InboundReceiptLinesRepository inboundReceiptLinesRepository;
+    private final InboundReceiptsRepository inboundReceiptsRepository;
+    private final OutboundShipmentLinesRepository outboundShipmentLinesRepository;
+    private final OutboundShipmentsRepository outboundShipmentsRepository;
+    private final StockMovementsRepository stockMovementsRepository;
+    private final PurchaseOrdersRepository purchaseOrdersRepository;
+    private final SalesOrdersRepository salesOrdersRepository;
+    private final BusinessPartnersRepository businessPartnersRepository;
+    private final LocationRepository locationRepository;
+    private final WareHouseRepository wareHouseRepository;
 
     @Override
     @Transactional
     public BatchResponse createBatch(CreateBatchRequest request) {
-
         Products product = productRepository.findById(request.getProductId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PROD_001));
-
-        if (!product.getRequiresBatchTracking()) {
+        if (!Boolean.TRUE.equals(product.getRequiresBatchTracking())) {
             throw new BadRequestException(ErrorCode.BATCH_009);
         }
-
-        if (batchRepository.existsByProductIdAndBatchNumber(
-                request.getProductId(),
-                request.getBatchNumber())) {
-
-            log.warn("Batch already exists: productId={}, batchNumber={}",
-                    request.getProductId(), request.getBatchNumber());
-
+        if (batchRepository.existsByProductIdAndBatchNumber(request.getProductId(), request.getBatchNumber())) {
+            log.warn("Batch already exists: productId={}, batchNumber={}", request.getProductId(), request.getBatchNumber());
             throw new BadRequestException(ErrorCode.BATCH_002);
         }
-
-        if (request.getManufacturingDate() != null
-                && request.getManufacturingDate().isAfter(LocalDate.now())) {
+        if (request.getManufacturingDate() != null && request.getManufacturingDate().isAfter(LocalDate.now())) {
             throw new BadRequestException(ErrorCode.BATCH_005);
         }
-
         if (request.getManufacturingDate() != null
                 && request.getExpiryDate() != null
                 && request.getExpiryDate().isBefore(request.getManufacturingDate())) {
             throw new BadRequestException(ErrorCode.BATCH_006);
         }
-
         Account currentUser = getCurrentUser();
-
         Batch batch = batchMapper.createEntity(request);
         batch.setStatus(BatchStatus.AVAILABLE);
         setAuditFieldsForCreate(batch, currentUser);
-
         Batch savedBatch = batchRepository.save(batch);
-
         log.info("Batch created successfully with ID={} by user={}", savedBatch.getId(), currentUser.getUsername());
-
         return batchMapper.toResponse(savedBatch);
     }
 
@@ -99,11 +136,7 @@ public class BatchServiceImpl implements BatchService {
     public BatchResponse getBatchById(String id) {
         log.info("Fetching batch by ID: {}", id);
         Batch batch = batchRepository.findById(id)
-                .orElseThrow(() -> {
-                    log.warn("Batch not found with id={}", id);
-                    return new NotFoundException(ErrorCode.BATCH_001);
-                });
-
+                .orElseThrow(() -> new NotFoundException(ErrorCode.BATCH_001));
         return batchMapper.toResponse(batch);
     }
 
@@ -113,11 +146,9 @@ public class BatchServiceImpl implements BatchService {
         log.info("Fetching all batches - page={}, size={}", page, size);
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         Page<Batch> batchPage = batchRepository.findAll(pageable);
-        List<BatchResponse> responses = batchPage.getContent()
-                .stream()
+        List<BatchResponse> responses = batchPage.getContent().stream()
                 .map(batchMapper::toResponse)
                 .collect(Collectors.toList());
-
         return PageResponse.from(batchPage, responses);
     }
 
@@ -133,41 +164,28 @@ public class BatchServiceImpl implements BatchService {
     public BatchResponse updateBatch(String id, UpdateBatchRequest request) {
         Batch batch = batchRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.BATCH_001));
-
-        if (request.getBatchNumber() != null && batchRepository.existsByProductIdAndBatchNumberAndIdNot(
-                batch.getProductId(),
-                request.getBatchNumber(),
-                id
-        )) {
+        if (request.getBatchNumber() != null
+                && batchRepository.existsByProductIdAndBatchNumberAndIdNot(batch.getProductId(), request.getBatchNumber(), id)) {
             throw new BadRequestException(ErrorCode.BATCH_002);
         }
-
         LocalDate manufacturingDate = request.getManufacturingDate() != null
                 ? request.getManufacturingDate()
                 : batch.getManufacturingDate();
-
         LocalDate expiryDate = request.getExpiryDate() != null
                 ? request.getExpiryDate()
                 : batch.getExpiryDate();
-
         if (manufacturingDate != null && manufacturingDate.isAfter(LocalDate.now())) {
             throw new BadRequestException(ErrorCode.BATCH_005);
         }
-
         if (expiryDate != null && manufacturingDate != null && expiryDate.isBefore(manufacturingDate)) {
             throw new BadRequestException(ErrorCode.BATCH_006);
         }
-
         batchMapper.updateEntity(request, batch);
-
         Account currentUser = getCurrentUser();
         setAuditFieldsForUpdate(batch, currentUser);
-
-        Batch updateBatch = batchRepository.save(batch);
-
-        log.info("Batch updated successfully with ID={} by user={}", updateBatch.getId(), currentUser.getUsername());
-
-        return batchMapper.toResponse(updateBatch);
+        Batch updatedBatch = batchRepository.save(batch);
+        log.info("Batch updated successfully with ID={} by user={}", updatedBatch.getId(), currentUser.getUsername());
+        return batchMapper.toResponse(updatedBatch);
     }
 
     @Override
@@ -175,93 +193,587 @@ public class BatchServiceImpl implements BatchService {
     public BatchResponse quarantineBatch(String id, QuarantineBatchRequest request) {
         Batch batch = batchRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.BATCH_001));
-
         validateQuarantine(batch);
-
         Account currentUser = getCurrentUser();
-
         batch.setStatus(BatchStatus.QUARANTINE);
         batch.setNotes(appendWorkflowNote(batch.getNotes(), buildQuarantineAuditNote(request)));
-
         setAuditFieldsForUpdate(batch, currentUser);
-
-        Batch saveBatch = batchRepository.save(batch);
-
-        log.info("Batch {} moved to QUARANTINE by user {}",
-                batch.getBatchNumber(), currentUser.getUsername());
-
-        return batchMapper.toResponse(saveBatch);
+        Batch savedBatch = batchRepository.save(batch);
+        log.info("Batch {} moved to QUARANTINE by user {}", batch.getBatchNumber(), currentUser.getUsername());
+        return batchMapper.toResponse(savedBatch);
     }
 
     @Override
     @Transactional
     public BatchResponse releaseBatch(String id, ReleaseBatchRequest request) {
-
         Batch batch = batchRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.BATCH_001));
-
         validateRelease(batch);
-
         Account user = getCurrentUser();
-
         batch.setStatus(BatchStatus.AVAILABLE);
         batch.setNotes(appendWorkflowNote(batch.getNotes(), buildReleaseAuditNote(request)));
-
         setAuditFieldsForUpdate(batch, user);
-
         Batch savedBatch = batchRepository.save(batch);
-
-        log.info("Batch {} released from QUARANTINE by user {}",
-                batch.getBatchNumber(), user.getUsername());
-
+        log.info("Batch {} released from QUARANTINE by user {}", batch.getBatchNumber(), user.getUsername());
         return batchMapper.toResponse(savedBatch);
     }
 
-    /**
-     * Validate business rules for quarantine
-     */
-    private void validateQuarantine(Batch batch) {
+    @Override
+    @Transactional
+    public BatchTraceabilityResponse getBatchTraceability(String id) {
+        Batch batch = getBatchOrThrow(id);
+        Products product = getProductOrThrow(batch.getProductId());
+        List<Inventory> inventories = inventoryRepository.findByBatchIdOrderByLastMovementAtDesc(id);
+        List<InboundReceiptLines> inboundLines = inboundReceiptLinesRepository.findByBatchIdOrderByCreatedAtDesc(id);
+        List<OutboundShipmentLines> outboundLines = outboundShipmentLinesRepository.findByBatchIdOrderByCreatedAtDesc(id);
+        List<StockMovements> stockMovements = stockMovementsRepository.findByBatchIdOrderByMovementDateDesc(id);
 
+        Map<String, InboundReceipts> inboundReceiptsById = toEntityMap(
+                inboundReceiptsRepository.findAllById(collectIds(inboundLines, InboundReceiptLines::getInboundReceiptId)));
+        Map<String, PurchaseOrders> purchaseOrdersById = toEntityMap(
+                purchaseOrdersRepository.findAllById(collectIds(inboundReceiptsById.values(), InboundReceipts::getPurchaseOrderId)));
+        Map<String, OutboundShipments> outboundShipmentsById = toEntityMap(
+                outboundShipmentsRepository.findAllById(collectIds(outboundLines, OutboundShipmentLines::getOutboundShipmentId)));
+        Map<String, SalesOrders> salesOrdersById = toEntityMap(
+                salesOrdersRepository.findAllById(collectIds(outboundShipmentsById.values(), OutboundShipments::getSalesOrderId)));
+
+        Set<String> businessPartnerIds = new LinkedHashSet<>();
+        businessPartnerIds.addAll(collectIds(purchaseOrdersById.values(), PurchaseOrders::getSupplierId));
+        businessPartnerIds.addAll(collectIds(salesOrdersById.values(), SalesOrders::getCustomerId));
+        Map<String, BusinessPartners> businessPartnerMap = toEntityMap(businessPartnersRepository.findAllById(businessPartnerIds));
+
+        Set<String> warehouseIds = new LinkedHashSet<>();
+        warehouseIds.addAll(collectIds(inventories, Inventory::getWarehouseId));
+        warehouseIds.addAll(collectIds(inboundReceiptsById.values(), InboundReceipts::getWarehouseId));
+        warehouseIds.addAll(collectIds(outboundShipmentsById.values(), OutboundShipments::getWarehouseId));
+        warehouseIds.addAll(collectIds(stockMovements, StockMovements::getWarehouseId));
+        Map<String, Warehouses> warehouseMap = toEntityMap(wareHouseRepository.findAllById(warehouseIds));
+
+        Set<String> locationIds = new LinkedHashSet<>();
+        locationIds.addAll(collectIds(inventories, Inventory::getLocationId));
+        locationIds.addAll(collectIds(inboundLines, InboundReceiptLines::getLocationId));
+        locationIds.addAll(collectIds(outboundLines, OutboundShipmentLines::getLocationId));
+        locationIds.addAll(collectIds(stockMovements, StockMovements::getLocationId));
+        Map<String, Locations> locationMap = toEntityMap(locationRepository.findAllById(locationIds));
+
+        return BatchTraceabilityResponse.builder()
+                .batchId(batch.getId())
+                .batchNumber(batch.getBatchNumber())
+                .productId(product.getId())
+                .productSku(product.getSku())
+                .productName(product.getName())
+                .status(batch.getStatus())
+                .manufacturingDate(batch.getManufacturingDate())
+                .expiryDate(batch.getExpiryDate())
+                .supplierBatchNumber(batch.getSupplierBatchNumber())
+                .notes(batch.getNotes())
+                .inventorySnapshot(buildInventorySnapshot(inventories, warehouseMap, locationMap))
+                .inboundReceipts(buildInboundTraceabilityEvents(
+                        inboundLines, inboundReceiptsById, purchaseOrdersById, businessPartnerMap, warehouseMap, locationMap))
+                .outboundShipments(buildOutboundTraceabilityEvents(
+                        outboundLines, outboundShipmentsById, salesOrdersById, businessPartnerMap, warehouseMap, locationMap))
+                .stockMovements(buildStockMovementEvents(stockMovements, warehouseMap, locationMap))
+                .workflowNotes(extractWorkflowNotes(batch.getNotes()))
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public List<BatchExpiringResponse> getExpiringBatches(Integer thresholdDays, String warehouseId) {
+        int effectiveThreshold = thresholdDays == null ? 30 : thresholdDays;
+        String normalizedWarehouseId = normalizeOptional(warehouseId);
+        if (normalizedWarehouseId != null) {
+            validateWarehouseExists(normalizedWarehouseId);
+        }
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = today.plusDays(effectiveThreshold);
+        List<Batch> batches = batchRepository.findExpiringBatches(today, endDate, EXPIRING_BATCH_STATUSES);
+        if (batches.isEmpty()) {
+            return List.of();
+        }
+        Map<String, Products> productMap = toEntityMap(productRepository.findAllById(collectIds(batches, Batch::getProductId)));
+        List<Inventory> inventories = normalizedWarehouseId == null
+                ? inventoryRepository.findByBatchIdIn(collectIds(batches, Batch::getId))
+                : inventoryRepository.findByWarehouseIdAndBatchIdIn(normalizedWarehouseId, collectIds(batches, Batch::getId));
+        Map<String, List<Inventory>> inventoryByBatch = groupInventoriesByBatch(inventories);
+        Map<String, Warehouses> warehouseMap = toEntityMap(wareHouseRepository.findAllById(collectIds(inventories, Inventory::getWarehouseId)));
+        Map<String, Locations> locationMap = toEntityMap(locationRepository.findAllById(collectIds(inventories, Inventory::getLocationId)));
+        return batches.stream()
+                .map(batch -> buildExpiringResponse(batch, productMap.get(batch.getProductId()), inventoryByBatch, warehouseMap, locationMap, today))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public List<BatchFifoRecommendationResponse> getFifoRecommendations(String productId, String warehouseId, Integer limit) {
+        Products product = getBatchTrackedProductOrThrow(productId);
+        Warehouses warehouse = validateWarehouseExists(warehouseId);
+        int effectiveLimit = limit == null ? 5 : limit;
+        LocalDate today = LocalDate.now();
+        List<Batch> batches = batchRepository.findByProductIdOrderByManufacturingDateAscExpiryDateAscCreatedAtAsc(productId);
+        if (batches.isEmpty()) {
+            return List.of();
+        }
+        List<Inventory> inventories = inventoryRepository.findByProductIdAndWarehouseIdAndBatchIdIn(
+                productId, warehouseId, collectIds(batches, Batch::getId));
+        Map<String, List<Inventory>> inventoryByBatch = groupInventoriesByBatch(inventories);
+        Map<String, Warehouses> warehouseMap = Map.of(warehouse.getId(), warehouse);
+        Map<String, Locations> locationMap = toEntityMap(locationRepository.findAllById(collectIds(inventories, Inventory::getLocationId)));
+        List<BatchFifoRecommendationResponse> responses = new ArrayList<>();
+        int rank = 1;
+        for (Batch batch : batches) {
+            if (batch.getStatus() != BatchStatus.AVAILABLE) {
+                continue;
+            }
+            if (batch.getExpiryDate() != null && !batch.getExpiryDate().isAfter(today)) {
+                continue;
+            }
+            List<Inventory> batchInventories = inventoryByBatch.getOrDefault(batch.getId(), List.of());
+            if (!hasPositiveAvailableQuantity(batchInventories)) {
+                continue;
+            }
+            responses.add(BatchFifoRecommendationResponse.builder()
+                    .recommendationRank(rank++)
+                    .batchId(batch.getId())
+                    .batchNumber(batch.getBatchNumber())
+                    .productId(product.getId())
+                    .productSku(product.getSku())
+                    .productName(product.getName())
+                    .warehouseId(warehouse.getId())
+                    .warehouseCode(warehouse.getCode())
+                    .warehouseName(warehouse.getName())
+                    .status(batch.getStatus())
+                    .manufacturingDate(batch.getManufacturingDate())
+                    .expiryDate(batch.getExpiryDate())
+                    .daysToExpiry(daysToExpiry(batch.getExpiryDate(), today))
+                    .inventorySnapshot(buildInventorySnapshot(batchInventories, warehouseMap, locationMap))
+                    .build());
+            if (responses.size() >= effectiveLimit) {
+                break;
+            }
+        }
+        return responses;
+    }
+
+    @Override
+    @Transactional
+    public List<BatchByProductResponse> getBatchesByProduct(String productId, String warehouseId) {
+        Products product = getBatchTrackedProductOrThrow(productId);
+        String normalizedWarehouseId = normalizeOptional(warehouseId);
+        if (normalizedWarehouseId != null) {
+            validateWarehouseExists(normalizedWarehouseId);
+        }
+        List<Batch> batches = batchRepository.findByProductIdOrderByManufacturingDateAscExpiryDateAscCreatedAtAsc(productId);
+        if (batches.isEmpty()) {
+            return List.of();
+        }
+        List<Inventory> inventories = normalizedWarehouseId == null
+                ? inventoryRepository.findByProductIdAndBatchIdIn(productId, collectIds(batches, Batch::getId))
+                : inventoryRepository.findByProductIdAndWarehouseIdAndBatchIdIn(
+                        productId, normalizedWarehouseId, collectIds(batches, Batch::getId));
+        Map<String, List<Inventory>> inventoryByBatch = groupInventoriesByBatch(inventories);
+        Map<String, Warehouses> warehouseMap = toEntityMap(wareHouseRepository.findAllById(collectIds(inventories, Inventory::getWarehouseId)));
+        Map<String, Locations> locationMap = toEntityMap(locationRepository.findAllById(collectIds(inventories, Inventory::getLocationId)));
+        return batches.stream()
+                .filter(batch -> normalizedWarehouseId == null || !inventoryByBatch.getOrDefault(batch.getId(), List.of()).isEmpty())
+                .map(batch -> BatchByProductResponse.builder()
+                        .batchId(batch.getId())
+                        .batchNumber(batch.getBatchNumber())
+                        .productId(product.getId())
+                        .productSku(product.getSku())
+                        .productName(product.getName())
+                        .status(batch.getStatus())
+                        .manufacturingDate(batch.getManufacturingDate())
+                        .expiryDate(batch.getExpiryDate())
+                        .supplierBatchNumber(batch.getSupplierBatchNumber())
+                        .notes(batch.getNotes())
+                        .inventorySnapshot(buildInventorySnapshot(inventoryByBatch.getOrDefault(batch.getId(), List.of()), warehouseMap, locationMap))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private void validateQuarantine(Batch batch) {
         if (batch.getStatus() == BatchStatus.QUARANTINE) {
             throw new BadRequestException(ErrorCode.BATCH_013);
         }
-
         if (batch.getStatus() == BatchStatus.EXPIRED) {
             throw new BadRequestException(ErrorCode.BATCH_004);
         }
-
         if (batch.getStatus() == BatchStatus.RECALLED) {
             throw new BadRequestException(ErrorCode.BATCH_014);
         }
-
         if (batch.getStatus() != BatchStatus.AVAILABLE) {
             throw new BadRequestException(ErrorCode.BATCH_015);
         }
-
-        boolean hasReservedStock = inventoryRepository.existsReservedStockByBatchId(batch.getId());
-
-        if (hasReservedStock) {
+        if (inventoryRepository.existsReservedStockByBatchId(batch.getId())) {
             throw new BadRequestException(ErrorCode.BATCH_007);
         }
     }
 
-    /**
-     * Validate business rules for release
-     */
     private void validateRelease(Batch batch) {
-
         if (batch.getStatus() == BatchStatus.RECALLED) {
             throw new BadRequestException(ErrorCode.BATCH_018);
         }
-
         if (batch.getStatus() != BatchStatus.QUARANTINE) {
             throw new BadRequestException(ErrorCode.BATCH_016);
         }
-
-        if (batch.getExpiryDate() != null
-                && !batch.getExpiryDate().isAfter(LocalDate.now())) {
+        if (batch.getExpiryDate() != null && !batch.getExpiryDate().isAfter(LocalDate.now())) {
             throw new BadRequestException(ErrorCode.BATCH_017);
         }
+    }
+
+    private BatchTraceabilityResponse.InboundTraceabilityEvent buildInboundTraceabilityEvent(
+            InboundReceiptLines line,
+            Map<String, InboundReceipts> inboundReceiptsById,
+            Map<String, PurchaseOrders> purchaseOrdersById,
+            Map<String, BusinessPartners> businessPartnerMap,
+            Map<String, Warehouses> warehouseMap,
+            Map<String, Locations> locationMap) {
+        InboundReceipts receipt = inboundReceiptsById.get(line.getInboundReceiptId());
+        PurchaseOrders purchaseOrder = receipt == null ? null : purchaseOrdersById.get(receipt.getPurchaseOrderId());
+        BusinessPartners supplier = purchaseOrder == null ? null : businessPartnerMap.get(purchaseOrder.getSupplierId());
+        Warehouses warehouse = receipt == null ? null : warehouseMap.get(receipt.getWarehouseId());
+        Locations location = locationMap.get(line.getLocationId());
+        return BatchTraceabilityResponse.InboundTraceabilityEvent.builder()
+                .inboundReceiptId(line.getInboundReceiptId())
+                .receiptNumber(receipt == null ? null : receipt.getReceiptNumber())
+                .receiptDate(receipt == null ? null : receipt.getReceiptDate())
+                .receiptStatus(receipt == null ? null : receipt.getStatus())
+                .purchaseOrderId(receipt == null ? null : receipt.getPurchaseOrderId())
+                .purchaseOrderNumber(purchaseOrder == null ? null : purchaseOrder.getPurchaseOrderNumber())
+                .supplierId(purchaseOrder == null ? null : purchaseOrder.getSupplierId())
+                .supplierCode(supplier == null ? null : supplier.getCode())
+                .supplierName(supplier == null ? null : supplier.getName())
+                .warehouseId(receipt == null ? null : receipt.getWarehouseId())
+                .warehouseCode(warehouse == null ? null : warehouse.getCode())
+                .warehouseName(warehouse == null ? null : warehouse.getName())
+                .locationId(line.getLocationId())
+                .locationCode(location == null ? null : location.getCode())
+                .locationName(location == null ? null : location.getName())
+                .quantityReceived(line.getQuantityReceived())
+                .qualityStatus(line.getQualityStatus())
+                .notes(line.getNotes())
+                .createdAt(line.getCreatedAt())
+                .confirmedAt(receipt == null ? null : receipt.getConfirmedAt())
+                .build();
+    }
+
+    private List<BatchTraceabilityResponse.InboundTraceabilityEvent> buildInboundTraceabilityEvents(
+            List<InboundReceiptLines> inboundLines,
+            Map<String, InboundReceipts> inboundReceiptsById,
+            Map<String, PurchaseOrders> purchaseOrdersById,
+            Map<String, BusinessPartners> businessPartnerMap,
+            Map<String, Warehouses> warehouseMap,
+            Map<String, Locations> locationMap) {
+        return inboundLines.stream()
+                .map(line -> buildInboundTraceabilityEvent(line, inboundReceiptsById, purchaseOrdersById, businessPartnerMap, warehouseMap, locationMap))
+                .collect(Collectors.toList());
+    }
+
+    private BatchTraceabilityResponse.OutboundTraceabilityEvent buildOutboundTraceabilityEvent(
+            OutboundShipmentLines line,
+            Map<String, OutboundShipments> outboundShipmentsById,
+            Map<String, SalesOrders> salesOrdersById,
+            Map<String, BusinessPartners> businessPartnerMap,
+            Map<String, Warehouses> warehouseMap,
+            Map<String, Locations> locationMap) {
+        OutboundShipments shipment = outboundShipmentsById.get(line.getOutboundShipmentId());
+        SalesOrders salesOrder = shipment == null ? null : salesOrdersById.get(shipment.getSalesOrderId());
+        BusinessPartners customer = salesOrder == null ? null : businessPartnerMap.get(salesOrder.getCustomerId());
+        Warehouses warehouse = shipment == null ? null : warehouseMap.get(shipment.getWarehouseId());
+        Locations location = locationMap.get(line.getLocationId());
+        return BatchTraceabilityResponse.OutboundTraceabilityEvent.builder()
+                .outboundShipmentId(line.getOutboundShipmentId())
+                .shipmentNumber(shipment == null ? null : shipment.getShipmentNumber())
+                .shipmentDate(shipment == null ? null : shipment.getShipmentDate())
+                .shipmentStatus(shipment == null ? null : shipment.getStatus())
+                .salesOrderId(shipment == null ? null : shipment.getSalesOrderId())
+                .salesOrderNumber(salesOrder == null ? null : salesOrder.getSoNumber())
+                .customerId(salesOrder == null ? null : salesOrder.getCustomerId())
+                .customerCode(customer == null ? null : customer.getCode())
+                .customerName(customer == null ? null : customer.getName())
+                .warehouseId(shipment == null ? null : shipment.getWarehouseId())
+                .warehouseCode(warehouse == null ? null : warehouse.getCode())
+                .warehouseName(warehouse == null ? null : warehouse.getName())
+                .locationId(line.getLocationId())
+                .locationCode(location == null ? null : location.getCode())
+                .locationName(location == null ? null : location.getName())
+                .quantityShipped(line.getQuantityShipped())
+                .pickedAt(line.getPickedAt())
+                .notes(line.getNotes())
+                .createdAt(line.getCreatedAt())
+                .shippedAt(shipment == null ? null : shipment.getShippedAt())
+                .build();
+    }
+
+    private List<BatchTraceabilityResponse.OutboundTraceabilityEvent> buildOutboundTraceabilityEvents(
+            List<OutboundShipmentLines> outboundLines,
+            Map<String, OutboundShipments> outboundShipmentsById,
+            Map<String, SalesOrders> salesOrdersById,
+            Map<String, BusinessPartners> businessPartnerMap,
+            Map<String, Warehouses> warehouseMap,
+            Map<String, Locations> locationMap) {
+        return outboundLines.stream()
+                .map(line -> buildOutboundTraceabilityEvent(line, outboundShipmentsById, salesOrdersById, businessPartnerMap, warehouseMap, locationMap))
+                .collect(Collectors.toList());
+    }
+
+    private List<BatchTraceabilityResponse.StockMovementTraceabilityEvent> buildStockMovementEvents(
+            List<StockMovements> stockMovements,
+            Map<String, Warehouses> warehouseMap,
+            Map<String, Locations> locationMap) {
+        return stockMovements.stream()
+                .map(movement -> {
+                    Warehouses warehouse = warehouseMap.get(movement.getWarehouseId());
+                    Locations location = locationMap.get(movement.getLocationId());
+                    return BatchTraceabilityResponse.StockMovementTraceabilityEvent.builder()
+                            .stockMovementId(movement.getId())
+                            .movementType(movement.getMovementType())
+                            .movementDate(movement.getMovementDate())
+                            .warehouseId(movement.getWarehouseId())
+                            .warehouseCode(warehouse == null ? null : warehouse.getCode())
+                            .warehouseName(warehouse == null ? null : warehouse.getName())
+                            .locationId(movement.getLocationId())
+                            .locationCode(location == null ? null : location.getCode())
+                            .locationName(location == null ? null : location.getName())
+                            .quantityChange(movement.getQuantityChange())
+                            .quantityBefore(movement.getQuantityBefore())
+                            .quantityAfter(movement.getQuantityAfter())
+                            .referenceType(movement.getReferenceType())
+                            .referenceId(movement.getReferenceId())
+                            .referenceNumber(movement.getReferenceNumber())
+                            .notes(movement.getNotes())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private BatchExpiringResponse buildExpiringResponse(
+            Batch batch,
+            Products product,
+            Map<String, List<Inventory>> inventoryByBatch,
+            Map<String, Warehouses> warehouseMap,
+            Map<String, Locations> locationMap,
+            LocalDate today) {
+        List<Inventory> inventories = inventoryByBatch.getOrDefault(batch.getId(), List.of());
+        if (!hasPhysicalStock(inventories)) {
+            return null;
+        }
+        return BatchExpiringResponse.builder()
+                .batchId(batch.getId())
+                .batchNumber(batch.getBatchNumber())
+                .productId(batch.getProductId())
+                .productSku(product == null ? null : product.getSku())
+                .productName(product == null ? null : product.getName())
+                .status(batch.getStatus())
+                .manufacturingDate(batch.getManufacturingDate())
+                .expiryDate(batch.getExpiryDate())
+                .daysToExpiry(daysToExpiry(batch.getExpiryDate(), today))
+                .urgency(resolveExpiryUrgency(batch.getExpiryDate(), today))
+                .inventorySnapshot(buildInventorySnapshot(inventories, warehouseMap, locationMap))
+                .build();
+    }
+
+    private BatchInventorySnapshotResponse buildInventorySnapshot(
+            List<Inventory> inventories,
+            Map<String, Warehouses> warehouseMap,
+            Map<String, Locations> locationMap) {
+        List<Inventory> safeInventories = inventories == null ? List.of() : inventories;
+        BigDecimal totalOnHandQuantity = sumInventories(safeInventories, Inventory::getOnHandQuantity);
+        BigDecimal totalQuarantineQuantity = sumInventories(safeInventories, Inventory::getQuarantineQuantity);
+        BigDecimal totalReservedQuantity = sumInventories(safeInventories, Inventory::getReservedQuantity);
+        BigDecimal totalAvailableQuantity = sumInventories(safeInventories, Inventory::getAvailableQuantity);
+        List<BatchInventorySnapshotResponse.WarehouseInventoryResponse> warehouseResponses = safeInventories.isEmpty()
+                ? List.of()
+                : groupInventoriesByWarehouse(safeInventories).entrySet().stream()
+                        .sorted(Comparator.comparing(entry -> resolveWarehouseSortKey(entry.getKey(), warehouseMap)))
+                        .map(entry -> buildWarehouseInventoryResponse(entry.getKey(), entry.getValue(), warehouseMap, locationMap))
+                        .collect(Collectors.toList());
+        return BatchInventorySnapshotResponse.builder()
+                .totalOnHandQuantity(totalOnHandQuantity)
+                .totalQuarantineQuantity(totalQuarantineQuantity)
+                .totalReservedQuantity(totalReservedQuantity)
+                .totalAvailableQuantity(totalAvailableQuantity)
+                .warehouseCount(safeInventories.stream().map(Inventory::getWarehouseId).filter(Objects::nonNull).distinct().count())
+                .locationCount(safeInventories.stream().map(Inventory::getLocationId).filter(Objects::nonNull).distinct().count())
+                .warehouses(warehouseResponses)
+                .build();
+    }
+
+    private BatchInventorySnapshotResponse.WarehouseInventoryResponse buildWarehouseInventoryResponse(
+            String warehouseId,
+            List<Inventory> warehouseInventories,
+            Map<String, Warehouses> warehouseMap,
+            Map<String, Locations> locationMap) {
+        Warehouses warehouse = warehouseMap.get(warehouseId);
+        List<BatchInventorySnapshotResponse.LocationInventoryResponse> locationResponses = groupInventoriesByLocation(warehouseInventories)
+                .entrySet().stream()
+                .sorted(Comparator.comparing(entry -> resolveLocationSortKey(entry.getKey(), locationMap)))
+                .map(entry -> buildLocationInventoryResponse(entry.getKey(), entry.getValue(), locationMap))
+                .collect(Collectors.toList());
+        return BatchInventorySnapshotResponse.WarehouseInventoryResponse.builder()
+                .warehouseId(warehouseId)
+                .warehouseCode(warehouse == null ? null : warehouse.getCode())
+                .warehouseName(warehouse == null ? null : warehouse.getName())
+                .onHandQuantity(sumInventories(warehouseInventories, Inventory::getOnHandQuantity))
+                .quarantineQuantity(sumInventories(warehouseInventories, Inventory::getQuarantineQuantity))
+                .reservedQuantity(sumInventories(warehouseInventories, Inventory::getReservedQuantity))
+                .availableQuantity(sumInventories(warehouseInventories, Inventory::getAvailableQuantity))
+                .locationCount(warehouseInventories.stream().map(Inventory::getLocationId).filter(Objects::nonNull).distinct().count())
+                .locations(locationResponses)
+                .build();
+    }
+
+    private BatchInventorySnapshotResponse.LocationInventoryResponse buildLocationInventoryResponse(
+            String locationKey,
+            List<Inventory> locationInventories,
+            Map<String, Locations> locationMap) {
+        String locationId = NO_LOCATION_KEY.equals(locationKey) ? null : locationKey;
+        Locations location = locationId == null ? null : locationMap.get(locationId);
+        LocalDateTime lastMovementAt = locationInventories.stream()
+                .map(Inventory::getLastMovementAt)
+                .filter(Objects::nonNull)
+                .max(LocalDateTime::compareTo)
+                .orElse(null);
+        return BatchInventorySnapshotResponse.LocationInventoryResponse.builder()
+                .locationId(locationId)
+                .locationCode(location == null ? null : location.getCode())
+                .locationName(location == null ? null : location.getName())
+                .onHandQuantity(sumInventories(locationInventories, Inventory::getOnHandQuantity))
+                .quarantineQuantity(sumInventories(locationInventories, Inventory::getQuarantineQuantity))
+                .reservedQuantity(sumInventories(locationInventories, Inventory::getReservedQuantity))
+                .availableQuantity(sumInventories(locationInventories, Inventory::getAvailableQuantity))
+                .lastMovementAt(lastMovementAt)
+                .build();
+    }
+
+    private Map<String, List<Inventory>> groupInventoriesByBatch(List<Inventory> inventories) {
+        return inventories.stream()
+                .filter(inventory -> inventory.getBatchId() != null)
+                .collect(Collectors.groupingBy(Inventory::getBatchId, LinkedHashMap::new, Collectors.toList()));
+    }
+
+    private Map<String, List<Inventory>> groupInventoriesByWarehouse(List<Inventory> inventories) {
+        return inventories.stream()
+                .collect(Collectors.groupingBy(Inventory::getWarehouseId, LinkedHashMap::new, Collectors.toList()));
+    }
+
+    private Map<String, List<Inventory>> groupInventoriesByLocation(List<Inventory> inventories) {
+        Map<String, List<Inventory>> inventoryByLocation = new LinkedHashMap<>();
+        for (Inventory inventory : inventories) {
+            String locationKey = inventory.getLocationId() == null ? NO_LOCATION_KEY : inventory.getLocationId();
+            inventoryByLocation.computeIfAbsent(locationKey, unused -> new ArrayList<>()).add(inventory);
+        }
+        return inventoryByLocation;
+    }
+
+    private boolean hasPhysicalStock(List<Inventory> inventories) {
+        return sumInventories(inventories, Inventory::getOnHandQuantity).compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    private boolean hasPositiveAvailableQuantity(List<Inventory> inventories) {
+        return sumInventories(inventories, Inventory::getAvailableQuantity).compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    private BigDecimal sumInventories(List<Inventory> inventories, Function<Inventory, BigDecimal> extractor) {
+        return inventories.stream()
+                .map(extractor)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private String resolveWarehouseSortKey(String warehouseId, Map<String, Warehouses> warehouseMap) {
+        Warehouses warehouse = warehouseMap.get(warehouseId);
+        if (warehouse == null) {
+            return warehouseId == null ? "" : warehouseId;
+        }
+        return warehouse.getCode() == null ? Optional.ofNullable(warehouse.getName()).orElse(warehouse.getId()) : warehouse.getCode();
+    }
+
+    private String resolveLocationSortKey(String locationId, Map<String, Locations> locationMap) {
+        if (NO_LOCATION_KEY.equals(locationId)) {
+            return "";
+        }
+        Locations location = locationMap.get(locationId);
+        if (location == null) {
+            return locationId == null ? "" : locationId;
+        }
+        return location.getCode() == null ? Optional.ofNullable(location.getName()).orElse(location.getId()) : location.getCode();
+    }
+
+    private Long daysToExpiry(LocalDate expiryDate, LocalDate today) {
+        return expiryDate == null ? null : ChronoUnit.DAYS.between(today, expiryDate);
+    }
+
+    private String resolveExpiryUrgency(LocalDate expiryDate, LocalDate today) {
+        Long daysToExpiry = daysToExpiry(expiryDate, today);
+        if (daysToExpiry == null) {
+            return null;
+        }
+        if (daysToExpiry <= 7) {
+            return "CRITICAL";
+        }
+        if (daysToExpiry <= 14) {
+            return "WARNING";
+        }
+        return "INFO";
+    }
+
+    private List<String> extractWorkflowNotes(String notes) {
+        if (notes == null || notes.isBlank()) {
+            return List.of();
+        }
+        return notes.lines()
+                .map(String::trim)
+                .filter(line -> line.startsWith("[QUARANTINE]") || line.startsWith("[RELEASE]"))
+                .collect(Collectors.toList());
+    }
+
+    private Batch getBatchOrThrow(String batchId) {
+        return batchRepository.findById(batchId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.BATCH_001));
+    }
+
+    private Products getProductOrThrow(String productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PROD_001));
+    }
+
+    private Products getBatchTrackedProductOrThrow(String productId) {
+        Products product = getProductOrThrow(productId);
+        if (!Boolean.TRUE.equals(product.getRequiresBatchTracking())) {
+            throw new BadRequestException(ErrorCode.BATCH_009);
+        }
+        return product;
+    }
+
+    private Warehouses validateWarehouseExists(String warehouseId) {
+        return wareHouseRepository.findById(warehouseId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.WHS_001));
+    }
+
+    private String normalizeOptional(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    private <T> Set<String> collectIds(Collection<T> items, Function<T, String> extractor) {
+        if (items == null || items.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return items.stream()
+                .map(extractor)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private <T extends BaseEntity> Map<String, T> toEntityMap(Collection<T> entities) {
+        if (entities == null || entities.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return entities.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(BaseEntity::getId, Function.identity(), (left, right) -> left, LinkedHashMap::new));
     }
 
     private String appendWorkflowNote(String existingNotes, String workflowNote) {
@@ -275,13 +787,10 @@ public class BatchServiceImpl implements BatchService {
     }
 
     private String buildQuarantineAuditNote(QuarantineBatchRequest request) {
-        StringBuilder note = new StringBuilder("[QUARANTINE] reason=")
-                .append(request.getReason());
-
+        StringBuilder note = new StringBuilder("[QUARANTINE] reason=").append(request.getReason());
         if (request.getExpectedResolutionDate() != null) {
             note.append("; expected_resolution_date=").append(request.getExpectedResolutionDate());
         }
-
         note.append("; notify_manager=").append(Boolean.TRUE.equals(request.getNotifyManager()));
         return note.toString();
     }
@@ -295,21 +804,13 @@ public class BatchServiceImpl implements BatchService {
         batch.setUpdatedBy(user.getId());
     }
 
-    /**
-     * Set audit fields when updating batch
-     */
     private void setAuditFieldsForUpdate(Batch batch, Account user) {
         batch.setUpdatedBy(user.getId());
         batch.setUpdatedAt(LocalDateTime.now());
     }
 
-    /**
-     * Get current authenticated user
-     */
     private Account getCurrentUser() {
-
         String username = SecurityUtils.getCurrentUsername();
-
         return accountRepository.findByUsername(username)
                 .orElseThrow(() -> {
                     log.error("No authenticated user found with username: {}", username);

--- a/src/test/java/org/demo/whs/controller/BatchQueryControllerTest.java
+++ b/src/test/java/org/demo/whs/controller/BatchQueryControllerTest.java
@@ -1,0 +1,222 @@
+package org.demo.whs.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.demo.whs.entity.dto.response.Batch.BatchByProductResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchExpiringResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchFifoRecommendationResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchInventorySnapshotResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchTraceabilityResponse;
+import org.demo.whs.entity.enums.BatchStatus;
+import org.demo.whs.exception.GlobalExceptionHandle;
+import org.demo.whs.service.BatchService;
+import org.demo.whs.service.RateLimitService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BatchController.class)
+@ActiveProfiles("test")
+@WithMockUser
+@Import({BatchQueryControllerTest.TestSecurityConfig.class, GlobalExceptionHandle.class})
+@ImportAutoConfiguration(JacksonAutoConfiguration.class)
+class BatchQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private BatchService batchService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @Test
+    @DisplayName("Should get batch traceability when request is valid")
+    void should_GetBatchTraceability_When_RequestIsValid() throws Exception {
+        when(batchService.getBatchTraceability("batch-1")).thenReturn(buildTraceabilityResponse());
+
+        mockMvc.perform(get("/api/v1/batches/{id}/traceability", "batch-1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.batch_id").value("batch-1"))
+                .andExpect(jsonPath("$.data.inventory_snapshot.total_available_quantity").value(7))
+                .andExpect(jsonPath("$.message").value("Batch traceability retrieved successfully"));
+
+        verify(batchService).getBatchTraceability("batch-1");
+    }
+
+    @Test
+    @DisplayName("Should get expiring batches when request is valid")
+    void should_GetExpiringBatches_When_RequestIsValid() throws Exception {
+        when(batchService.getExpiringBatches(30, "W1")).thenReturn(List.of(buildExpiringResponse()));
+
+        mockMvc.perform(get("/api/v1/batches/expiring")
+                        .param("threshold_days", "30")
+                        .param("warehouse_id", "W1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].batch_id").value("batch-1"))
+                .andExpect(jsonPath("$.data[0].urgency").value("CRITICAL"));
+
+        verify(batchService).getExpiringBatches(30, "W1");
+    }
+
+    @Test
+    @DisplayName("Should get FIFO recommendations when request is valid")
+    void should_GetFifoRecommendations_When_RequestIsValid() throws Exception {
+        when(batchService.getFifoRecommendations("prod-1", "W1", 5)).thenReturn(List.of(buildFifoResponse()));
+
+        mockMvc.perform(get("/api/v1/batches/fifo-recommendations")
+                        .param("product_id", "prod-1")
+                        .param("warehouse_id", "W1")
+                        .param("limit", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].recommendation_rank").value(1))
+                .andExpect(jsonPath("$.data[0].warehouse_id").value("W1"));
+
+        verify(batchService).getFifoRecommendations("prod-1", "W1", 5);
+    }
+
+    @Test
+    @DisplayName("Should return 400 when FIFO limit is invalid")
+    void should_Return400_When_FifoLimitIsInvalid() throws Exception {
+        mockMvc.perform(get("/api/v1/batches/fifo-recommendations")
+                        .param("product_id", "prod-1")
+                        .param("warehouse_id", "W1")
+                        .param("limit", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error_code").value("COM_001"));
+    }
+
+    @Test
+    @DisplayName("Should get batches by product when request is valid")
+    void should_GetBatchesByProduct_When_RequestIsValid() throws Exception {
+        when(batchService.getBatchesByProduct("prod-1", "W1")).thenReturn(List.of(buildByProductResponse()));
+
+        mockMvc.perform(get("/api/v1/batches/by-product/{productId}", "prod-1")
+                        .param("warehouse_id", "W1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].batch_id").value("batch-1"))
+                .andExpect(jsonPath("$.data[0].inventory_snapshot.total_on_hand_quantity").value(8));
+
+        verify(batchService).getBatchesByProduct("prod-1", "W1");
+    }
+
+    private BatchTraceabilityResponse buildTraceabilityResponse() {
+        return BatchTraceabilityResponse.builder()
+                .batchId("batch-1")
+                .batchNumber("BATCH-001")
+                .productId("prod-1")
+                .productSku("SKU-1")
+                .productName("Paracetamol")
+                .status(BatchStatus.AVAILABLE)
+                .manufacturingDate(LocalDate.now().minusDays(10))
+                .expiryDate(LocalDate.now().plusDays(20))
+                .inventorySnapshot(buildInventorySnapshot("10", "1", "2", "7"))
+                .workflowNotes(List.of("[QUARANTINE] reason=Quality hold"))
+                .build();
+    }
+
+    private BatchExpiringResponse buildExpiringResponse() {
+        return BatchExpiringResponse.builder()
+                .batchId("batch-1")
+                .batchNumber("BATCH-001")
+                .productId("prod-1")
+                .productSku("SKU-1")
+                .productName("Paracetamol")
+                .status(BatchStatus.AVAILABLE)
+                .expiryDate(LocalDate.now().plusDays(5))
+                .daysToExpiry(5L)
+                .urgency("CRITICAL")
+                .inventorySnapshot(buildInventorySnapshot("8", "0", "1", "7"))
+                .build();
+    }
+
+    private BatchFifoRecommendationResponse buildFifoResponse() {
+        return BatchFifoRecommendationResponse.builder()
+                .recommendationRank(1)
+                .batchId("batch-1")
+                .batchNumber("BATCH-001")
+                .productId("prod-1")
+                .productSku("SKU-1")
+                .productName("Paracetamol")
+                .warehouseId("W1")
+                .warehouseCode("WH-01")
+                .warehouseName("Main Warehouse")
+                .status(BatchStatus.AVAILABLE)
+                .manufacturingDate(LocalDate.now().minusDays(30))
+                .expiryDate(LocalDate.now().plusDays(10))
+                .daysToExpiry(10L)
+                .inventorySnapshot(buildInventorySnapshot("5", "0", "0", "5"))
+                .build();
+    }
+
+    private BatchByProductResponse buildByProductResponse() {
+        return BatchByProductResponse.builder()
+                .batchId("batch-1")
+                .batchNumber("BATCH-001")
+                .productId("prod-1")
+                .productSku("SKU-1")
+                .productName("Paracetamol")
+                .status(BatchStatus.AVAILABLE)
+                .expiryDate(LocalDate.now().plusDays(10))
+                .inventorySnapshot(buildInventorySnapshot("8", "1", "0", "7"))
+                .build();
+    }
+
+    private BatchInventorySnapshotResponse buildInventorySnapshot(String onHand, String quarantine, String reserved, String available) {
+        return BatchInventorySnapshotResponse.builder()
+                .totalOnHandQuantity(new BigDecimal(onHand))
+                .totalQuarantineQuantity(new BigDecimal(quarantine))
+                .totalReservedQuantity(new BigDecimal(reserved))
+                .totalAvailableQuantity(new BigDecimal(available))
+                .warehouseCount(1L)
+                .locationCount(1L)
+                .warehouses(List.of())
+                .build();
+    }
+
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                    .formLogin(AbstractHttpConfigurer::disable)
+                    .httpBasic(AbstractHttpConfigurer::disable);
+            return http.build();
+        }
+    }
+}

--- a/src/test/java/org/demo/whs/service/impl/BatchQueryServiceImplTest.java
+++ b/src/test/java/org/demo/whs/service/impl/BatchQueryServiceImplTest.java
@@ -1,0 +1,300 @@
+package org.demo.whs.service.impl;
+
+import org.demo.whs.entity.Batch;
+import org.demo.whs.entity.BusinessPartners;
+import org.demo.whs.entity.InboundReceiptLines;
+import org.demo.whs.entity.InboundReceipts;
+import org.demo.whs.entity.Inventory;
+import org.demo.whs.entity.Locations;
+import org.demo.whs.entity.OutboundShipmentLines;
+import org.demo.whs.entity.OutboundShipments;
+import org.demo.whs.entity.Products;
+import org.demo.whs.entity.PurchaseOrders;
+import org.demo.whs.entity.SalesOrders;
+import org.demo.whs.entity.StockMovements;
+import org.demo.whs.entity.Warehouses;
+import org.demo.whs.entity.dto.response.Batch.BatchByProductResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchExpiringResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchFifoRecommendationResponse;
+import org.demo.whs.entity.dto.response.Batch.BatchTraceabilityResponse;
+import org.demo.whs.entity.enums.BatchStatus;
+import org.demo.whs.entity.enums.InboundReceiptsStatus;
+import org.demo.whs.entity.enums.OutboundShipmentsStatus;
+import org.demo.whs.entity.enums.QualityStatus;
+import org.demo.whs.entity.enums.ReferenceType;
+import org.demo.whs.entity.enums.StockMovementsType;
+import org.demo.whs.mapper.BatchMapper;
+import org.demo.whs.repository.AccountRepository;
+import org.demo.whs.repository.BatchRepository;
+import org.demo.whs.repository.BusinessPartnersRepository;
+import org.demo.whs.repository.InboundReceiptLinesRepository;
+import org.demo.whs.repository.InboundReceiptsRepository;
+import org.demo.whs.repository.InventoryRepository;
+import org.demo.whs.repository.LocationRepository;
+import org.demo.whs.repository.OutboundShipmentLinesRepository;
+import org.demo.whs.repository.OutboundShipmentsRepository;
+import org.demo.whs.repository.ProductRepository;
+import org.demo.whs.repository.PurchaseOrdersRepository;
+import org.demo.whs.repository.SalesOrdersRepository;
+import org.demo.whs.repository.StockMovementsRepository;
+import org.demo.whs.repository.WareHouseRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BatchQueryServiceImplTest {
+
+    @Mock private AccountRepository accountRepository;
+    @Mock private InventoryRepository inventoryRepository;
+    @Mock private ProductRepository productRepository;
+    @Mock private BatchRepository batchRepository;
+    @Mock private BatchMapper batchMapper;
+    @Mock private InboundReceiptLinesRepository inboundReceiptLinesRepository;
+    @Mock private InboundReceiptsRepository inboundReceiptsRepository;
+    @Mock private OutboundShipmentLinesRepository outboundShipmentLinesRepository;
+    @Mock private OutboundShipmentsRepository outboundShipmentsRepository;
+    @Mock private StockMovementsRepository stockMovementsRepository;
+    @Mock private PurchaseOrdersRepository purchaseOrdersRepository;
+    @Mock private SalesOrdersRepository salesOrdersRepository;
+    @Mock private BusinessPartnersRepository businessPartnersRepository;
+    @Mock private LocationRepository locationRepository;
+    @Mock private WareHouseRepository wareHouseRepository;
+
+    @InjectMocks
+    private BatchServiceImpl batchService;
+
+    @Test
+    void should_GetBatchTraceability_When_BatchHasLinkedTransactions() {
+        Batch batch = batch("B1", "P1", "BATCH-001", BatchStatus.AVAILABLE, 20, 10);
+        batch.setNotes("Manual note\n[QUARANTINE] reason=Quality hold");
+        Products product = product("P1", "SKU-1", "Paracetamol");
+        Warehouses warehouse = warehouse("W1", "WH-01", "Main Warehouse");
+        Locations location = location("L1", "A-01", "Rack A-01");
+        Inventory inventory = inventory("B1", "P1", "W1", "L1", "10", "1", "2");
+
+        InboundReceiptLines inboundLine = new InboundReceiptLines();
+        inboundLine.setInboundReceiptId("IR1");
+        inboundLine.setLocationId("L1");
+        inboundLine.setBatchId("B1");
+        inboundLine.setQuantityReceived(new BigDecimal("5"));
+        inboundLine.setQualityStatus(QualityStatus.PASS);
+        inboundLine.setCreatedAt(LocalDateTime.now().minusDays(3));
+
+        InboundReceipts inboundReceipt = new InboundReceipts();
+        inboundReceipt.setId("IR1");
+        inboundReceipt.setReceiptNumber("IR-001");
+        inboundReceipt.setReceiptDate(LocalDate.now().minusDays(3));
+        inboundReceipt.setStatus(InboundReceiptsStatus.CONFIRMED);
+        inboundReceipt.setPurchaseOrderId("PO1");
+        inboundReceipt.setWarehouseId("W1");
+
+        PurchaseOrders purchaseOrder = new PurchaseOrders();
+        purchaseOrder.setId("PO1");
+        purchaseOrder.setPurchaseOrderNumber("PO-001");
+        purchaseOrder.setSupplierId("SUP1");
+
+        BusinessPartners supplier = new BusinessPartners();
+        supplier.setId("SUP1");
+        supplier.setCode("SUP-01");
+        supplier.setName("Supplier A");
+
+        OutboundShipmentLines outboundLine = new OutboundShipmentLines();
+        outboundLine.setOutboundShipmentId("OS1");
+        outboundLine.setLocationId("L1");
+        outboundLine.setBatchId("B1");
+        outboundLine.setQuantityShipped(new BigDecimal("3"));
+        outboundLine.setPickedAt(LocalDateTime.now().minusDays(1));
+
+        OutboundShipments outboundShipment = new OutboundShipments();
+        outboundShipment.setId("OS1");
+        outboundShipment.setShipmentNumber("OS-001");
+        outboundShipment.setShipmentDate(LocalDate.now().minusDays(1));
+        outboundShipment.setStatus(OutboundShipmentsStatus.SHIPPED);
+        outboundShipment.setSalesOrderId("SO1");
+        outboundShipment.setWarehouseId("W1");
+
+        SalesOrders salesOrder = new SalesOrders();
+        salesOrder.setId("SO1");
+        salesOrder.setSoNumber("SO-001");
+        salesOrder.setCustomerId("CUS1");
+
+        BusinessPartners customer = new BusinessPartners();
+        customer.setId("CUS1");
+        customer.setCode("CUS-01");
+        customer.setName("Customer A");
+
+        StockMovements movement = new StockMovements();
+        movement.setId("SM1");
+        movement.setMovementType(StockMovementsType.INBOUND);
+        movement.setMovementDate(LocalDateTime.now().minusDays(3));
+        movement.setWarehouseId("W1");
+        movement.setLocationId("L1");
+        movement.setQuantityChange(new BigDecimal("5"));
+        movement.setQuantityBefore(BigDecimal.ZERO);
+        movement.setQuantityAfter(new BigDecimal("5"));
+        movement.setReferenceType(ReferenceType.INBOUND_RECEIPT);
+        movement.setReferenceId("IR1");
+        movement.setReferenceNumber("IR-001");
+
+        when(batchRepository.findById("B1")).thenReturn(Optional.of(batch));
+        when(productRepository.findById("P1")).thenReturn(Optional.of(product));
+        when(inventoryRepository.findByBatchIdOrderByLastMovementAtDesc("B1")).thenReturn(List.of(inventory));
+        when(inboundReceiptLinesRepository.findByBatchIdOrderByCreatedAtDesc("B1")).thenReturn(List.of(inboundLine));
+        when(inboundReceiptsRepository.findAllById(any())).thenReturn(List.of(inboundReceipt));
+        when(purchaseOrdersRepository.findAllById(any())).thenReturn(List.of(purchaseOrder));
+        when(outboundShipmentLinesRepository.findByBatchIdOrderByCreatedAtDesc("B1")).thenReturn(List.of(outboundLine));
+        when(outboundShipmentsRepository.findAllById(any())).thenReturn(List.of(outboundShipment));
+        when(salesOrdersRepository.findAllById(any())).thenReturn(List.of(salesOrder));
+        when(stockMovementsRepository.findByBatchIdOrderByMovementDateDesc("B1")).thenReturn(List.of(movement));
+        when(businessPartnersRepository.findAllById(any())).thenReturn(List.of(supplier, customer));
+        when(wareHouseRepository.findAllById(any())).thenReturn(List.of(warehouse));
+        when(locationRepository.findAllById(any())).thenReturn(List.of(location));
+
+        BatchTraceabilityResponse response = batchService.getBatchTraceability("B1");
+
+        assertThat(response.getBatchId()).isEqualTo("B1");
+        assertThat(response.getProductSku()).isEqualTo("SKU-1");
+        assertThat(response.getInboundReceipts()).hasSize(1);
+        assertThat(response.getOutboundShipments()).hasSize(1);
+        assertThat(response.getStockMovements()).hasSize(1);
+        assertThat(response.getWorkflowNotes()).containsExactly("[QUARANTINE] reason=Quality hold");
+        assertThat(response.getInventorySnapshot().getTotalAvailableQuantity()).isEqualByComparingTo("7");
+    }
+
+    @Test
+    void should_GetExpiringBatches_When_BatchesStillHaveStock() {
+        Batch expiring = batch("B1", "P1", "BATCH-001", BatchStatus.AVAILABLE, 12, 5);
+        Batch noStock = batch("B2", "P1", "BATCH-002", BatchStatus.AVAILABLE, 15, 6);
+        Products product = product("P1", "SKU-1", "Paracetamol");
+        Warehouses warehouse = warehouse("W1", "WH-01", "Main Warehouse");
+        Locations location = location("L1", "A-01", "Rack A-01");
+
+        when(batchRepository.findExpiringBatches(any(), any(), any())).thenReturn(List.of(expiring, noStock));
+        when(productRepository.findAllById(any())).thenReturn(List.of(product));
+        when(inventoryRepository.findByBatchIdIn(any())).thenReturn(List.of(inventory("B1", "P1", "W1", "L1", "8", "0", "1")));
+        when(wareHouseRepository.findAllById(any())).thenReturn(List.of(warehouse));
+        when(locationRepository.findAllById(any())).thenReturn(List.of(location));
+
+        List<BatchExpiringResponse> responses = batchService.getExpiringBatches(30, null);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getBatchId()).isEqualTo("B1");
+        assertThat(responses.get(0).getInventorySnapshot().getTotalOnHandQuantity()).isEqualByComparingTo("8");
+    }
+
+    @Test
+    void should_GetFifoRecommendations_When_OnlyEligibleBatchesRemain() {
+        Products product = product("P1", "SKU-1", "Paracetamol");
+        Warehouses warehouse = warehouse("W1", "WH-01", "Main Warehouse");
+        Locations location = location("L1", "A-01", "Rack A-01");
+        Batch oldest = batch("B1", "P1", "BATCH-001", BatchStatus.AVAILABLE, 30, 10);
+        Batch newer = batch("B2", "P1", "BATCH-002", BatchStatus.AVAILABLE, 10, 20);
+        Batch quarantine = batch("B3", "P1", "BATCH-003", BatchStatus.QUARANTINE, 20, 15);
+
+        when(productRepository.findById("P1")).thenReturn(Optional.of(product));
+        when(wareHouseRepository.findById("W1")).thenReturn(Optional.of(warehouse));
+        when(batchRepository.findByProductIdOrderByManufacturingDateAscExpiryDateAscCreatedAtAsc("P1"))
+                .thenReturn(List.of(oldest, newer, quarantine));
+        when(inventoryRepository.findByProductIdAndWarehouseIdAndBatchIdIn(any(), any(), any())).thenReturn(List.of(
+                inventory("B1", "P1", "W1", "L1", "5", "0", "0"),
+                inventory("B2", "P1", "W1", "L1", "4", "0", "1"),
+                inventory("B3", "P1", "W1", "L1", "7", "0", "0")
+        ));
+        when(locationRepository.findAllById(any())).thenReturn(List.of(location));
+
+        List<BatchFifoRecommendationResponse> responses = batchService.getFifoRecommendations("P1", "W1", 5);
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getBatchId()).isEqualTo("B1");
+        assertThat(responses.get(0).getRecommendationRank()).isEqualTo(1);
+        assertThat(responses.get(1).getBatchId()).isEqualTo("B2");
+    }
+
+    @Test
+    void should_GetBatchesByProduct_When_WarehouseFilterProvided() {
+        Products product = product("P1", "SKU-1", "Paracetamol");
+        Warehouses warehouse = warehouse("W1", "WH-01", "Main Warehouse");
+        Locations location = location("L1", "A-01", "Rack A-01");
+        Batch available = batch("B1", "P1", "BATCH-001", BatchStatus.AVAILABLE, 20, 10);
+        Batch hidden = batch("B2", "P1", "BATCH-002", BatchStatus.AVAILABLE, 15, 8);
+
+        when(productRepository.findById("P1")).thenReturn(Optional.of(product));
+        when(wareHouseRepository.findById("W1")).thenReturn(Optional.of(warehouse));
+        when(batchRepository.findByProductIdOrderByManufacturingDateAscExpiryDateAscCreatedAtAsc("P1"))
+                .thenReturn(List.of(available, hidden));
+        when(inventoryRepository.findByProductIdAndWarehouseIdAndBatchIdIn(any(), any(), any()))
+                .thenReturn(List.of(inventory("B1", "P1", "W1", "L1", "6", "1", "0")));
+        when(wareHouseRepository.findAllById(any())).thenReturn(List.of(warehouse));
+        when(locationRepository.findAllById(any())).thenReturn(List.of(location));
+
+        List<BatchByProductResponse> responses = batchService.getBatchesByProduct("P1", "W1");
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getBatchId()).isEqualTo("B1");
+        assertThat(responses.get(0).getInventorySnapshot().getTotalAvailableQuantity()).isEqualByComparingTo("5");
+    }
+
+    private Products product(String id, String sku, String name) {
+        Products product = new Products();
+        product.setId(id);
+        product.setSku(sku);
+        product.setName(name);
+        product.setRequiresBatchTracking(true);
+        return product;
+    }
+
+    private Batch batch(String id, String productId, String batchNumber, BatchStatus status, long expiryInDays, long manufacturingDaysAgo) {
+        Batch batch = new Batch();
+        batch.setId(id);
+        batch.setProductId(productId);
+        batch.setBatchNumber(batchNumber);
+        batch.setStatus(status);
+        batch.setExpiryDate(LocalDate.now().plusDays(expiryInDays));
+        batch.setManufacturingDate(LocalDate.now().minusDays(manufacturingDaysAgo));
+        return batch;
+    }
+
+    private Inventory inventory(String batchId, String productId, String warehouseId, String locationId,
+                                String onHand, String quarantine, String reserved) {
+        Inventory inventory = new Inventory();
+        inventory.setBatchId(batchId);
+        inventory.setProductId(productId);
+        inventory.setWarehouseId(warehouseId);
+        inventory.setLocationId(locationId);
+        inventory.setOnHandQuantity(new BigDecimal(onHand));
+        inventory.setQuarantineQuantity(new BigDecimal(quarantine));
+        inventory.setReservedQuantity(new BigDecimal(reserved));
+        inventory.setLastMovementAt(LocalDateTime.now().minusHours(2));
+        return inventory;
+    }
+
+    private Warehouses warehouse(String id, String code, String name) {
+        Warehouses warehouse = new Warehouses();
+        warehouse.setId(id);
+        warehouse.setCode(code);
+        warehouse.setName(name);
+        return warehouse;
+    }
+
+    private Locations location(String id, String code, String name) {
+        Locations location = new Locations();
+        location.setId(id);
+        location.setCode(code);
+        location.setName(name);
+        return location;
+    }
+}


### PR DESCRIPTION
## Summary
- add Batch traceability, expiring, FIFO recommendation, and by-product APIs
- extend the Batch query surface required by the remaining `WHS-35` scope
- connect Batch reads across inventory, movement, inbound, and outbound records

## Context
This PR is the third implementation step of the sequenced `WHS-35` Batch delivery.
Baselines `WHS-83` and `WHS-41` are already merged into `develop`.

## Jira
- `WHS-42`
- parent: `WHS-35`